### PR TITLE
Added LibcWrapGenerator.vala and a README file.

### DIFF
--- a/LibcWrapGenerator/LibcWrapGenerator.vala
+++ b/LibcWrapGenerator/LibcWrapGenerator.vala
@@ -1,0 +1,353 @@
+/*
+ * Copyright (C) 2011 Jan Niklas Hasse <jhasse@gmail.com>
+ * Copyright (C) 2013 Upstairs Laboratories Inc.
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Authors:
+ *   Jan Niklas Hasse <jhasse@gmail.com>
+ *   Tristan Van Berkom <tristan@upstairslabs.com>
+ */
+using GLib;
+
+static const string DEFAULT_TARGET      = "2.7";
+static const string DEFAULT_TARGET_HELP = "Target glibc ABI (Default 2.7)";
+
+/***************************************************************
+ *                      Debugging Facilities                   *
+ ***************************************************************/
+[Flags]
+public enum DF { 
+	COLLECT,
+	FILTER
+}
+
+static const GLib.DebugKey[] libcwrap_debug_keys = {
+	{ "collect", DF.COLLECT },
+	{ "filter", DF.FILTER } 
+};
+
+private bool libcwrap_debug_initialized = false;
+private uint libcwrap_debug_mask = 0;
+public delegate void DebugFunc ();
+
+public void libcwrap_note (int domain, DebugFunc debug_func)
+{
+	if (!libcwrap_debug_initialized) {
+		string libcwrap_debug_env = GLib.Environment.get_variable ("LIBCWRAP_DEBUG");
+
+		libcwrap_debug_mask = GLib.parse_debug_string (libcwrap_debug_env, libcwrap_debug_keys);
+		libcwrap_debug_initialized = true;
+	}
+
+	if ((libcwrap_debug_mask & domain) != 0)
+		debug_func ();
+}
+
+/***************************************************************
+ *                      VersionNumber class                    *
+ ***************************************************************/
+class VersionNumber : Object
+{
+	private int major    { get; set; } // x.0.0
+	private int minor    { get; set; } // 0.x.0
+	private int revision { get; set; } // 0.0.x
+	private string originalString;
+	
+	public VersionNumber (string version) {
+
+		originalString = version;
+
+		try {
+			var regex = new Regex("([[:digit:]]*)\\.([[:digit:]]*)\\.*([[:digit:]]*)");
+			var split = regex.split(version);
+			
+			assert (split.length > 1); // TODO: Don't use assert, print a nice error message instead
+			major = int.parse (split[1]);
+			
+			if (split.length > 2)
+				minor = int.parse (split[2]);
+			else
+				minor = 0;
+
+			if (split.length > 3)
+				revision = int.parse (split[3]);
+			else
+				revision = 0;
+		} catch (GLib.RegexError e) {
+			stdout.printf ("Error compiling regular expression: %s", e.message);
+			Posix.exit(-1);
+		}
+	}
+
+	public bool newerThan(VersionNumber other) {
+
+		if (major > other.major) {
+			return true;
+		} else if (major == other.major) {
+
+			if (minor > other.minor) {
+				return true;
+			} else if (minor == other.minor) {
+
+				if(revision > other.revision) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	public string getString() {
+		return originalString;
+	}
+}
+
+/***************************************************************
+ *                             Main                            *
+ ***************************************************************/
+public class Main : Object {
+
+	/* Command line options */
+	private static string? libdir = null;
+	private static string? output = null;
+	private static string? target = null;
+
+	private const GLib.OptionEntry[] options = {
+		{ "libdir", 'l', 0, OptionArg.FILENAME, ref libdir, "Library directory", "<DIRECTORY>" },
+		{ "output", 'o', 0, OptionArg.STRING,   ref output, "Header to create",  "<FILENAME>" },
+		{ "target", 't', 0, OptionArg.STRING,   ref target, DEFAULT_TARGET_HELP, "<MAJOR.MINOR[.MICRO]>" },
+		{ null }
+	};
+
+	/* Local variables */
+	private static VersionNumber minimumVersion;
+	private static Gee.HashMap<string, VersionNumber>symbolMap;
+	private static Gee.HashSet<string>filterMap;
+
+	public static int main (string[] args) {
+
+		/* Initialize the default here */
+		target = DEFAULT_TARGET;
+
+		try {
+			var opt_context = new OptionContext ("- Libc compatibility header generator");
+			opt_context.set_help_enabled (true);
+			opt_context.add_main_entries (options, null);
+			opt_context.parse (ref args);
+		} catch (OptionError e) {
+			stdout.printf ("error: %s\n", e.message);
+			stdout.printf ("Run '%s --help' for a list of available command line options.\n", args[0]);
+			return 0;
+		}
+
+		if (libdir == null) {
+			stdout.printf ("Must specify --libdir\n");
+			stdout.printf ("Run '%s --help' for a list of available command line options.\n", args[0]);
+			return 0;
+		}
+
+		if (output == null) {
+			stdout.printf ("Must specify --output\n");
+			stdout.printf ("Run '%s --help' for a list of available command line options.\n", args[0]);
+			return 0;
+		}
+
+		/* Initialize local resources */
+		minimumVersion = new VersionNumber (target);
+
+		/* All symbols, containing the newest possible version before 'minimumVersion' if possible */
+		symbolMap = new Gee.HashMap<string, VersionNumber>((Gee.HashDataFunc<string>)GLib.str_hash,
+														   (Gee.EqualDataFunc<string>)GLib.str_equal);
+
+		/* All symbols which did not have any version > minimumVersion */
+		filterMap = new Gee.HashSet<string>((Gee.HashDataFunc<string>)GLib.str_hash,
+											(Gee.EqualDataFunc<string>)GLib.str_equal);
+
+		try {
+
+			stdout.printf ("Generating %s (glibc %s) from libs at '%s' .", output, minimumVersion.getString(), libdir);
+
+			parseLibraries ();
+			generateHeader ();
+
+		} catch (Error e) {
+
+			warning("%s", e.message);
+			return 1;
+		}
+
+		stdout.printf(" OK\n");
+
+		return 0;
+	}
+
+	private static void parseLibrary (Regex regex, FileInfo fileinfo) throws Error {
+
+		string output, errorOutput;
+		int returnCode;
+
+		Process.spawn_command_line_sync ("objdump -T " + libdir + "/" + fileinfo.get_name(), 
+										 out output, out errorOutput, out returnCode);
+
+		if (returnCode != 0)
+			return;
+
+		foreach (var line in output.split ("\n")) {
+
+			if (regex.match (line) && !("PRIVATE" in line)) {
+				var version      = new VersionNumber (regex.split (line)[3]);
+				var symbolName   = regex.split (line)[7];
+				var versionInMap = symbolMap.get (symbolName);
+
+				/* Some versioning symbols exist in the objdump output, let's skip those */
+				if (symbolName.has_prefix ("GLIBC"))
+					continue;
+
+				libcwrap_note (DF.COLLECT, () =>
+							   stdout.printf ("Selected symbol '%s' version '%s' from objdump line %s\n", 
+											  symbolName, version.getString(), line));
+
+				if (versionInMap == null) {
+
+					symbolMap.set (symbolName, version);
+
+					/* First occurance of the symbol, if it's older
+					 * than the minimum required, put it in that table also
+					 */
+					if (minimumVersion.newerThan (version)) {
+						filterMap.add (symbolName);
+						libcwrap_note (DF.FILTER, () =>
+									   stdout.printf ("Adding symbol '%s %s' to the filter\n", 
+													  symbolName, version.getString()));
+					}
+
+				} else {
+
+					/* We want the newest possible version of a symbol which is older than the
+					 * minimum glibc version specified (or the only version of the symbol if
+					 * it's newer than the minimum version)
+					 */
+					if (version.newerThan (versionInMap) && minimumVersion.newerThan (version))
+						symbolMap.set (symbolName, version);
+
+					/* While trucking along through the huge symbol list, remove symbols from
+					 * the 'safe to exclude' if there is a version found which is newer
+					 * than the minimum requirement
+					 */
+					if (version.newerThan (minimumVersion)) {
+						filterMap.remove(symbolName);
+						libcwrap_note (DF.FILTER, () =>
+									   stdout.printf ("Removing symbol '%s %s' from the filter\n", 
+													  symbolName, version.getString()));
+					}
+				}
+
+			} else {
+				libcwrap_note (DF.COLLECT, () => stdout.printf ("Rejected objdump line %s\n", line));
+			}
+		}
+	}
+
+	private static void parseLibraries () throws Error {
+		var libPath    = File.new_for_path (libdir);
+		var enumerator = libPath.enumerate_children (FileAttribute.STANDARD_NAME, 0, null);
+		var regex      = new Regex ("(.*)(GLIBC_)([0-9]+\\.([0-9]+\\.)*[0-9]+)(\\)?)([ ]*)(.+)");
+
+		var counter    = 0;
+		FileInfo fileinfo;
+
+		while ((fileinfo = enumerator.next_file(null)) != null) {
+
+			if (++counter % 50 == 0) {
+				stdout.printf(".");
+				stdout.flush();
+			}
+
+			parseLibrary (regex, fileinfo);
+		}
+	}
+
+	private static void appendSymbols (StringBuilder headerFile, bool unavailableSymbols) {
+
+		if (unavailableSymbols)
+			headerFile.append("\n/* Symbols introduced in newer glibc versions, which must not be used */\n");
+		else
+			headerFile.append("\n/* Symbols redirected to earlier glibc versions */\n");
+
+		foreach (var it in symbolMap.keys) {
+			var version = symbolMap.get (it);
+			string versionToUse;
+
+			/* If the symbol only has occurrences older than the minimum required glibc version,
+			 * then there is no need to output anything for this symbol
+			 */
+			if (filterMap.contains (it))
+				continue;
+
+			/* If the only available symbol is > minimumVersion, then redirect it
+			 * to a comprehensible linker error, otherwise redirect the symbol
+			 * to it's existing version <= minimumVersion.
+			 */
+			if (version.newerThan (minimumVersion)) {
+
+				versionToUse = "DONT_USE_THIS_VERSION_%s".printf (version.getString());
+				if (!unavailableSymbols)
+					continue;
+
+			} else {
+
+				versionToUse = version.getString ();
+				if (unavailableSymbols)
+					continue;
+			}
+
+			headerFile.append("__asm__(\".symver %s, %s@GLIBC_%s\");\n".printf(it, it, versionToUse));
+		}
+	}
+
+	private static void generateHeader () throws Error {
+		var headerFile = new StringBuilder ();
+
+		/* FIXME: Currently we do:
+		 *
+		 *   if !defined (__OBJC__) && !defined (__ASSEMBLER__)
+		 *
+		 * But what we want is a clause which accepts any form of C including C++ and probably
+		 * also including ObjC. That said, the generated header works fine for C and C++ sources.
+		 */
+		headerFile.append ("/* glibc bindings for target ABI version glibc " + minimumVersion.getString() + " */\n");
+		headerFile.append ("#if !defined (__LIBC_CUSTOM_BINDINGS_H__)\n");
+		headerFile.append ("\n");
+		headerFile.append ("#  if !defined (__OBJC__) && !defined (__ASSEMBLER__)\n");
+		headerFile.append ("#    if defined (__cplusplus)\n");
+		headerFile.append ("extern \"C\" {\n");
+		headerFile.append ("#    endif\n");
+
+		/* First generate the available redirected symbols, then the unavailable symbols */
+		appendSymbols (headerFile, false);
+		appendSymbols (headerFile, true);
+
+		headerFile.append ("\n");
+		headerFile.append ("#    if defined (__cplusplus)\n");
+		headerFile.append ("}\n");
+		headerFile.append ("#    endif\n");
+		headerFile.append ("#  endif /* !defined (__OBJC__) && !defined (__ASSEMBLER__) */\n");
+		headerFile.append ("#endif\n");
+
+		FileUtils.set_contents (output, headerFile.str);
+	}
+}

--- a/LibcWrapGenerator/README
+++ b/LibcWrapGenerator/README
@@ -1,0 +1,159 @@
+About the libc header file generator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The AppImageKit makes it possible to create bundles in a variety of ways.
+
+This utility is relevant for cases where you have a stack (program & dependencies)
+as source code on your computer and wish to build and bundle that stack.
+
+Particularly, this utility provides a method for selecting an arbitrary
+glibc ABI target version for the software you build on your modern linux
+distribution.
+
+Unfortunately the typical method employed for targetting an older version
+of glibc is to either build and install an alternative glibc on your
+machine, or to simply build your software on a very old linux distribution.
+
+We were not satisfied with this, and so we employ this technique instead.
+
+
+Compiling the generator
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To compile the LibcWrapGenerator you will require:
+  o A vala compiler (https://wiki.gnome.org/Projects/Vala)
+  o libgee 0.8 or later (https://wiki.gnome.org/Projects/Libgee)
+
+The generator can be created with the following command:
+
+  valac --pkg gee-0.8 --pkg posix --pkg glib-2.0 --pkg gio-2.0 LibcWrapGenerator.vala
+
+
+How to use the generator
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the LibcWrapGenerator program to generate a header file
+for your system, we typically call this "libcwrap.h"
+
+A typical invocation will look like this:
+
+  LibcWrapGenerator --target 2.7 --libdir /lib --output libcwrap.h
+
+This will create the libcwrap.h header file in such a way that
+it will provide backwards compatibility down to the 2.7 ABI of glibc,
+regardless of what version of glibc you have installed in /lib.
+
+
+Ok, now I have a header file, what do I do with it ?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When building your stack, you will probably be using some variety
+of build system (or you will be building software into a relocated
+directory by hand, package by package, which can work well if your
+dependency stack is relatively small).
+
+Regardless of how you build your stack, the technique is the same.
+
+These two variables need to be exported into your environment:
+
+  export CC='gcc -U_FORTIFY_SOURCE -include /path/to/libcwrap.h'
+  export CXX='g++ -U_FORTIFY_SOURCE -include /path/to/libcwrap.h'
+
+It is of paramount importance that the include of "libcwrap.h" comes
+before any other source code when compiling your C and C++ sources.
+
+This is why we override the CC and CXX variables instead of trying
+CFLAGS and CXXFLAGS variables (while the latter may work for some
+particular packages, using the CC and CXX variable overrides was
+found to be much more reliable).
+
+On more recent Ubuntu systems, gcc is distributed with an automatic
+definition of _FORTIFY_SOURCE, this definition enables alternative code
+paths to be enabled for runtime checking via glibc's header files.
+
+We forcefully undefine these variables because they often incur
+linkage to symbols for glibc which are very new.
+
+Having produced the "libcwrap.h" header file and compiled your
+software and dependencies using the prescribed techinique, your
+software will only require the glibc ABI version which you have
+specified at header generation time, otherwise your software will
+bail out with a linker error which might look like this:
+
+  "Undefined reference to fallocate@GLIBC_DONT_USE_THIS_VERSION_2.10"
+
+If you encounter any linker error like this, your source code must
+absolutely be patched to not use the fallocate() glibc function,
+which was introduced in glibc 2.10.
+
+
+How does the header file work ?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the brave hearted, and for posterity, here is brief explanation
+of how the "libcwrap.h" and it's generator work.
+
+The GNU toolchain provides a built in mechanism for providing forward
+compatibility in libraries. Not many libraries encode versioning information
+manually, but low level system libraries such as libc need to provide
+this, and usually do so in the form of linker scripts.
+
+What this forward compatibility does is ensure binary compatibility for
+older programs which were compiled for an older version of glibc, while
+allowing the library implementor some flexibility in changing their
+binary interface in the future. This is what symbol versioning is all about.
+
+So let's say that you had a version of glibc 2.10 on your system, and you
+compile a program which uses memcpy(). When the linker does it's magick,
+your resulting program links memcpy() to a versioned symbol in the glibc
+binary which is actually 'memcpy@GLIBC_2.2.5'
+
+Now, in glibc 2.14, it was decided that many programmers used memcpy() in
+cases where they actually desired the behaviour of memmove(), or their
+code was found to be unsafe, so in the interest of creating a more stable glibc,
+they have provided us with a new implementation of memcpy() which does that.
+That new symbol is named 'memcpy@GLIBC_2.14' in the new glibc ABI.
+
+If you update your system's glibc, or distribute that very same binary
+on a system with glibc 2.16, glibc will still contain the old version of
+memcpy() bound to the 'memcpy@GLIBC_2.2.5' symbol in it's lookup table.
+
+And there you have forward binary compatibility for your program.
+
+But what we want is the very opposite of the above. We want to use a modern
+GNU toolchain on a modern system with a modern glibc, but we want to have
+our programs backwards compatible for much older versions of glibc.
+
+Let's say that you actually have glibc 2.16 on your system and compile
+your stack against glibc, now you are linking against 'memcpy@GLIBC_2.14'
+and your program no longer works for older versions of glibc (but will
+maintain forward compatibility).
+
+The generated "libcwrap.h" file takes care of this by inserting a
+hand full of ".symver" directives, forcing the linker to link your
+new program to the newest possible version of any given symbol
+which exists *before* your target ABI version.
+
+For memcpy(), you will have a directive for gcc built in like so:
+
+    __asm__(".symver memcpy, memcpy@GLIBC_2.2.5");
+
+Of course, new symbols with no prior record will continue to be
+added to glibc, and it's possible that the version of glibc you
+want to target does not contain a symbol that your application
+requires.
+
+For these cases, we use the ".symver" directive to bind your
+application to a symbol which definitely does not exist, like so:
+
+    __asm__(".symver fallocate, fallocate@GLIBC_DONT_USE_THIS_VERSION_2.10");
+
+This generates a linker error when you try to link your program to
+fallocate(), informing the "libcwrap.h" user that the symbol they want
+simply does not exist in the target glibc version they selected. And
+also informs them in which version of glibc the symbol was initially
+added.
+
+The LibcWrapGenerator parses the output of 'objdump -T' on your
+system's C runtime libraries in order to introspect all the information
+needed to generate this header file for the system you are building on.


### PR DESCRIPTION
The LibcWrapGenerator program generates a header file allowing
one to target older versions of glibc than the version they have
installed on their GNU/Linux system.

The README file explains how to safely use the generator
and the generated header file, and also explains how the
generator and header file work.
