### PR TITLE
Make the code compatible with both, python2 and python3

### DIFF
--- a/AppImageAssistant.AppDir/package
+++ b/AppImageAssistant.AppDir/package
@@ -30,7 +30,6 @@ from __future__ import division
 import os, sys
 import subprocess 
 import xdgappdir 
-import commands
 from locale import gettext as _
 
 
@@ -43,7 +42,7 @@ if lddp == None: lddp = ""
 os.environ['LD_LIBRARY_PATH'] =  dependenciesdir + "/lib:" + lddp
 
 if len(sys.argv) == 2:
-    print "Assuming I should inject a new runtime"
+    print("Assuming I should inject a new runtime")
     destinationfile = os.path.realpath(sys.argv[1])
     should_compress = False
 elif len(sys.argv) < 3:
@@ -67,39 +66,38 @@ if should_compress == True:
     H = xdgappdir.AppDirXdgHandler(sourcedir)
     iconfile = H.get_icon_path_by_icon_name(H.get_icon_name_from_desktop_file(H.desktopfile))
     if iconfile == None:
-        print "Icon could not be found based on information in desktop file, aborting"
+        print("Icon could not be found based on information in desktop file, aborting")
         exit(1)
 
     print("Creating %s..." % (destinationfile))
-    if os.path.exists(destinationfile): 
-        print _("Destination path already exists, exiting") # xorriso would append another session to a pre-existing image
+    if os.path.exists(destinationfile):
+        print (_("Destination path already exists, exiting")) # xorriso would append another session to a pre-existing image
         exit(1)
     # As great as xorriso is, as cryptic its usage is :-(
-    command = ["xorriso", "-dev", 
+    command = ["xorriso", "-dev",
     destinationfile, "-padding", "0", "-map",
-    sourcedir, "/", "--", "-map", iconfile, "/.DirIcon", 
+    sourcedir, "/", "--", "-map", iconfile, "/.DirIcon",
     "-zisofs", "level=9:block_size=128k", "-chown_r", "0",
     "/", "--", "set_filter_r", "--zisofs", "/" ]
-					
+
     subprocess.Popen(command).communicate()
 
-    print "ok"
+    print("ok")
 
 print("Embedding runtime...")
-
 elf = os.path.realpath(os.path.dirname(__file__)) + "/runtime"
-s = file(elf, 'r')	
-f = file(destinationfile, 'r+')
-f.write(s.read())
+s = open(elf, 'rb')
+f = open(destinationfile, 'rb+')
+f.write(bytes(s.read()))
 f.close()
 s.close()
-print "ok"
+print("ok")
 
 print("Making %s executable..." % (destinationfile))
 
-os.chmod(destinationfile, 0755)
+os.chmod(destinationfile, 0o755)
 
-print "ok"
+print("ok")
 
 filesize = int(os.stat(destinationfile).st_size)
 print (_("Size: %f MB") % (filesize/1024/1024))

--- a/AppImageAssistant.AppDir/xdg/BaseDirectory.py
+++ b/AppImageAssistant.AppDir/xdg/BaseDirectory.py
@@ -56,7 +56,7 @@ def save_config_path(*resource):
     assert not resource.startswith('/')
     path = os.path.join(xdg_config_home, resource)
     if not os.path.isdir(path):
-        os.makedirs(path, 0700)
+        os.makedirs(path, 0o700)
     return path
 
 def save_data_path(*resource):

--- a/AppImageAssistant.AppDir/xdg/IconTheme.py
+++ b/AppImageAssistant.AppDir/xdg/IconTheme.py
@@ -250,7 +250,7 @@ def getIconPath(iconname, size = None, theme = None, extensions = ["png", "svg",
 
     # more caching (icon looked up in the last 5 seconds?)
     tmp = "".join([iconname, str(size), theme, "".join(extensions)])
-    if eache.has_key(tmp):
+    if tmp in eache:
         if int(time.time() - eache[tmp][0]) >= xdg.Config.cache_time:
             del eache[tmp]
         else:
@@ -264,7 +264,7 @@ def getIconPath(iconname, size = None, theme = None, extensions = ["png", "svg",
 
     # cache stuff again (directories lookuped up in the last 5 seconds?)
     for directory in icondirs:
-        if (not dache.has_key(directory) \
+        if (directory not in dache \
             or (int(time.time() - dache[directory][1]) >= xdg.Config.cache_time \
             and dache[directory][2] < os.path.getmtime(directory))) \
             and os.path.isdir(directory):
@@ -277,7 +277,7 @@ def getIconPath(iconname, size = None, theme = None, extensions = ["png", "svg",
                     icon = os.path.join(dir, iconname + "." + extension)
                     eache[tmp] = [time.time(), icon]
                     return icon
-            except UnicodeDecodeError, e:
+            except UnicodeDecodeError as e:
                 if debug:
                     raise e
                 else:
@@ -319,7 +319,7 @@ def __parseTheme(file):
 
 def LookupIcon(iconname, size, theme, extensions):
     # look for the cache
-    if not cache.has_key(theme.name):
+    if theme.name not in cache:
         cache[theme.name] = []
         cache[theme.name].append(time.time() - (xdg.Config.cache_time + 1)) # [0] last time of lookup
         cache[theme.name].append(0)               # [1] mtime
@@ -331,7 +331,7 @@ def LookupIcon(iconname, size, theme, extensions):
         for subdir in theme.getDirectories():
             for directory in icondirs:
                 dir = os.path.join(directory,theme.name,subdir)
-                if (not cache[theme.name][2].has_key(dir) \
+                if (cache not in ncache[theme.name][2] \
                 or cache[theme.name][1] < os.path.getmtime(os.path.join(directory,theme.name))) \
                 and subdir != "" \
                 and os.path.isdir(dir):
@@ -344,7 +344,7 @@ def LookupIcon(iconname, size, theme, extensions):
                 if iconname + "." + extension in values[1]:
                     return os.path.join(dir, iconname + "." + extension)
 
-    minimal_size = sys.maxint
+    minimal_size = float("inf")
     closest_filename = ""
     for dir, values in cache[theme.name][2].items():
         distance = DirectorySizeDistance(values[0], size, theme)

--- a/AppImageAssistant.AppDir/xdgappdir.py
+++ b/AppImageAssistant.AppDir/xdgappdir.py
@@ -26,9 +26,14 @@
 # 
 # **************************************************************************/
 
-import os, sys, commands, glob
+import os, sys, subprocess, glob
 import xdg.IconTheme, xdg.DesktopEntry # apt-get install python-xdg, present on Ubuntu
 from locale import gettext as _
+
+def get_status_output(*args, **kwargs):
+    p = subprocess.Popen(*args, **kwargs)
+    stdout, stderr = p.communicate()
+    return p.returncode, stdout, stderr
 
 class AppDirXdgHandler(object):
     
@@ -64,7 +69,7 @@ class AppDirXdgHandler(object):
     def _find_all_executables_in_appdir(self):
         """Return all executable files in the AppDir, or None"""
         results = []
-        result, executables = commands.getstatusoutput("find " + self.appdir + " -type f -perm -u+x")
+        result, executables = get_status_output("find " + self.appdir + " -type f -perm -u+x")
         executables = executables.split("\n")
         if result != 0:
             return None
@@ -108,9 +113,9 @@ class AppDirXdgHandler(object):
     
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print _("Usage: %s AppDir" % (sys.argv[0]))
+        print (_("Usage: %s AppDir" % (sys.argv[0])))
         exit(1)
     appdir = sys.argv[1]
     H = AppDirXdgHandler(appdir)
-    print H
+    print(H)
 

--- a/AppImageExtract.AppDir/usr/bin/appimageextract
+++ b/AppImageExtract.AppDir/usr/bin/appimageextract
@@ -21,15 +21,15 @@ else:
     response = dialog.run()
     if response == gtk.RESPONSE_OK:
         selection = dialog.get_filename()
-        print selection, 'selected'
+        print(selection, 'selected')
     elif response == gtk.RESPONSE_CANCEL:
-        print 'Closed, no files selected'
+        print('Closed, no files selected')
     dialog.destroy()
 
 name = os.path.basename(selection)
 appdir = os.path.expanduser("~/Desktop/" + name + ".AppDir")
 command = 'xorriso -indev "' + selection + '" -osirrox on -extract / "' + appdir + '"'
-print command
+print(command)
 os.system(command)
 os.system('sudo chown -R "${USER}" "' + appdir + '"')
 os.system('sudo chmod -R u+w "' + appdir + '"')


### PR DESCRIPTION
Instead of forcing the use of python2 we can make AppImageKit compatible with both python2 and python3 at the same time without obfuscating the code at all.
