### PR TITLE
Fix "fix" of identifiers

### DIFF
--- a/binreloc.c
+++ b/binreloc.c
@@ -24,9 +24,9 @@
 #include <string.h>
 #include "binreloc.h"
 
-#ifdef cplusplus
+#ifdef __cplusplus
 extern "C" {
-#endif /* cplusplus */
+#endif /* __cplusplus */
 
 
 
@@ -759,8 +759,8 @@ br_dirname (const char *path)
 }
 
 
-#ifdef cplusplus
+#ifdef __cplusplus
 }
-#endif /* cplusplus */
+#endif /* __cplusplus */
 
 #endif /* BINRELOC_C */

--- a/binreloc.h
+++ b/binreloc.h
@@ -13,9 +13,9 @@
 #ifndef BINRELOC_H
 #define BINRELOC_H
 
-#ifdef cplusplus
+#ifdef __cplusplus
 extern "C" {
-#endif /* cplusplus */
+#endif /* __cplusplus */
 
 
 /** These error codes can be returned by br_init(), br_init_lib(), gbr_init() or gbr_init_lib(). */
@@ -73,8 +73,8 @@ char *br_build_path (const char *dir, const char *file);
 char *br_dirname (const char *path);
 
 
-#ifdef cplusplus
+#ifdef __cplusplus
 }
-#endif /* cplusplus */
+#endif /* __cplusplus */
 
 #endif /* BINRELOC_H */


### PR DESCRIPTION
The `__cplusplus` reserved identifiers have accidentally been replaced
by the non-existing `cplusplus` identifier. Thanks @darealshinji for
reporting the problem in #372.

This commit fixes the bugs introduced in the two commits a1ef1cac and
c6ad4218.