### PR TITLE
Build smaller runtime, speed up building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ CC="cc -O2 -Wall -Wno-deprecated-declarations -Wno-unused-result"
 STRIP="strip"
 INSTALL_DEPENDENCIES=1
 STATIC_BUILD=1
-JOBS=$(nproc)
+JOBS=${JOBS:-1}
 
 while [ $1 ]; do
   case $1 in


### PR DESCRIPTION
Build a slightly smaller runtime binary (~ -16k on my system) and speed up the build process, especially OpenSSL.
The "small FLAGS" were only used on libraries that the runtime is linked against.