### PR TITLE
fix for debian

### DIFF
--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -4,7 +4,7 @@ set -e
 
 # Install build dependencies; TODO: Support systems that do not use apt-get (Pull Requests welcome!)
 
-ARCH=$(uname -p)
+ARCH=$(uname -m)
 if [ "$ARCH" == "i686" ]; then
   ARCH=i386
 fi
@@ -20,11 +20,16 @@ if [ -e /usr/bin/zypper ] ; then
 fi
 
 if [ -e /usr/bin/apt-get ] ; then
-  sudo apt-get update
-  sudo apt-get -y install zsync git libarchive-dev autoconf libtool make gcc libtool libfuse-dev \
-  liblzma-dev libglib2.0-dev libssl-dev libinotifytools0-dev liblz4-dev equivs libcairo-dev
-  # libtool-bin might be required in newer distributions but is not available in precise
-  sudo cp resources/liblz4.pc /usr/lib/$ARCH-linux-gnu/pkgconfig/
+    if [ $EUID -ne 0 ]; then 
+      echo "you must have root privileges for install (su or sudo su )"
+      exit 1
+    fi
+    apt-get update
+    pkglibtoolbin=$(apt-cache --generate pkgnames libtool-bin)
+    apt-get -y install zsync git libarchive-dev autoconf libtool make gcc libtool libfuse-dev \
+                       liblzma-dev libglib2.0-dev libssl-dev libinotifytools0-dev liblz4-dev \
+                       equivs libcairo2-dev $pkglibtoolbin
+    cp resources/liblz4.pc /usr/lib/$ARCH-linux-gnu/pkgconfig/
 fi
 
 if [ -e /usr/bin/yum ] ; then


### PR DESCRIPTION
as says [man uname](https://www.gnu.org/software/coreutils/manual/html_node/uname-invocation.html#uname-invocation), uname -p is not portable, replaced with uname -m

sudo is not installed as standard in debian, then test if root. if not, exit with information message

libcairo-dev unknow in debian and ubuntu. I imagine that it's libcairo2-dev:
```text
 libcairo2-dev | 1.12.2-3          | oldoldstable | amd64, i386
 libcairo2-dev | 1.14.0-2.1+deb8u2 | oldstable    | amd64, i386
 libcairo2-dev | 1.14.8-1          | stable       | amd64, i386
 libcairo2-dev | 1.14.10-1         | testing      | amd64, i386
 libcairo2-dev | 1.14.10-1         | unstable     | amd64, i386
 libcairo2-dev | 1.10.2-6.1ubuntu2          | precise         | amd64, i386
 libcairo2-dev | 1.10.2-6.1ubuntu3          | precise-updates | amd64, i386
 libcairo2-dev | 1.13.0~20140204-0ubuntu1   | trusty          | amd64, i386
 libcairo2-dev | 1.13.0~20140204-0ubuntu1.1 | trusty-updates  | amd64, i386
 libcairo2-dev | 1.14.2-1ubuntu1            | vivid           | amd64, i386
 libcairo2-dev | 1.14.6-1                   | xenial          | amd64, i386
 libcairo2-dev | 1.14.6-1build1             | yakkety         | amd64, i386
 libcairo2-dev | 1.14.8-1                   | zesty           | amd64, i386
 libcairo2-dev | 1.14.8-1                   | artful          | amd64, i386
 libcairo2-dev | 1.14.10-1                  | artful-proposed | amd64, i386
```
test if libtool-bin exists and installs, but libtool-bin is disposable in versions:
```
libtool-bin | 2.4.2-1.11+b1 | oldstable  | amd64, i386
libtool-bin | 2.4.6-2       | stable     | amd64, i386
libtool-bin | 2.4.6-2       | testing    | amd64, i386
libtool-bin | 2.4.6-2       | unstable   | amd64, i386
libtool-bin | 2.4.2-1.11 | vivid   | amd64, i386
libtool-bin | 2.4.6-0.1  | xenial  | amd64, i386
libtool-bin | 2.4.6-1    | yakkety | amd64, i386
libtool-bin | 2.4.6-2    | zesty   | amd64, i386
libtool-bin | 2.4.6-2    | artful  | amd64, i386
```
