### PR TITLE
Improve the way ignore files work

### DIFF
--- a/appimagetool.c
+++ b/appimagetool.c
@@ -55,6 +55,7 @@ extern int _binary_runtime_start;
 extern int _binary_runtime_end;
 
 static gchar const APPIMAGEIGNORE[] = ".appimageignore";
+static char _exclude_file_desc[256];
 
 static gboolean list = FALSE;
 static gboolean verbose = FALSE;
@@ -140,16 +141,6 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         // check if exclude file can be used
         GString* ef = 0;
 
-        // explicitly passed exclude file always overrides defaults
-        // if an empty string is passed, the default exclude file is ignored
-        if(exclude_file != 0)
-            if(strlen(exclude_file) > 0)
-                ef = g_string_new(exclude_file);
-            else
-                printf("WARNING: %s is ignored", APPIMAGEIGNORE);
-        else if(access(APPIMAGEIGNORE, F_OK) != -1)
-            ef = g_string_new(APPIMAGEIGNORE);
-
         if(use_xz) {
             // https://jonathancarter.org/2015/04/06/squashfs-performance-testing/ says:
             // improved performance by using a 16384 block size with a sacrifice of around 3% more squashfs image space
@@ -159,10 +150,28 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
             args[i++] = "16384";
         }
 
-        if(ef != 0 && ef->len > 0) {
+        // check if ignore file exists and use it if possible
+        if(access(APPIMAGEIGNORE, F_OK) != -1) {
+            printf("Including %s", APPIMAGEIGNORE);
             args[i++] = "-wildcards";
             args[i++] = "-ef";
-            args[i++] = ef->str;
+
+            // avoid warning: assignment discards ‘const’ qualifier
+            char buf[256];
+            strcpy(buf, APPIMAGEIGNORE);
+            args[i++] = buf;
+        }
+
+        // if an exclude file has been passed on the command line, should be used, too
+        if(exclude_file != 0 && strlen(exclude_file) > 0) {
+            if(!access(exclude_file, F_OK) != -1) {
+                printf("WARNING: exclude file %s not found!", exclude_file);
+                return -1;
+            } else {
+                args[i++] = "-wildcards";
+                args[i++] = "-ef";
+                args[i++] = exclude_file;
+            }
         }
 
         args[i++] = 0;
@@ -170,9 +179,9 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         execvp("mksquashfs", args);
 
         perror("execlp");   // exec*() returns only on error
-        return(-1); // exec never returns
+        return -1; // exec never returns
     }
-    return(0);
+    return 0;
 }
 
 /* Generate a squashfs filesystem
@@ -282,7 +291,7 @@ static GOptionEntry entries[] =
     { "sign", 's', 0, G_OPTION_ARG_NONE, &sign, "Sign with gpg2", NULL },
     { "comp", 0, 0, G_OPTION_ARG_STRING, &sqfs_comp, "Squashfs compression", NULL },
     { "no-appstream", 'n', 0, G_OPTION_ARG_NONE, &no_appstream, "Do not check AppStream metadata", NULL },
-    { "exclude-file", 0, 0, G_OPTION_ARG_STRING, &exclude_file, "Uses given file as exclude file for mksquashfs. By default, if .appimageignore exists, it will be used. Feature can be disabled completely by setting this option to an empty string.", NULL },
+    { "exclude-file", 0, 0, G_OPTION_ARG_STRING, &exclude_file, _exclude_file_desc, NULL },
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &remaining_args, NULL, NULL },
     { 0,0,0,0,0,0,0 }
 };
@@ -312,6 +321,9 @@ main (int argc, char *argv[])
     GError *error = NULL;
     GOptionContext *context;
     char command[PATH_MAX];
+
+    // initialize help text of argument
+    sprintf(_exclude_file_desc, "Uses given file as exclude file for mksquashfs, in addition to %s.", APPIMAGEIGNORE);
     
     context = g_option_context_new ("SOURCE [DESTINATION] - Generate, extract, and inspect AppImages");
     g_option_context_add_main_entries (context, entries, NULL);

--- a/appimagetool.c
+++ b/appimagetool.c
@@ -151,7 +151,7 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         }
 
         // check if ignore file exists and use it if possible
-        if(access(APPIMAGEIGNORE, F_OK) != -1) {
+        if(access(APPIMAGEIGNORE, F_OK) >= 0) {
             printf("Including %s", APPIMAGEIGNORE);
             args[i++] = "-wildcards";
             args[i++] = "-ef";
@@ -164,14 +164,14 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
 
         // if an exclude file has been passed on the command line, should be used, too
         if(exclude_file != 0 && strlen(exclude_file) > 0) {
-            if(!access(exclude_file, F_OK) != -1) {
+            if(access(exclude_file, F_OK) < 0) {
                 printf("WARNING: exclude file %s not found!", exclude_file);
                 return -1;
-            } else {
-                args[i++] = "-wildcards";
-                args[i++] = "-ef";
-                args[i++] = exclude_file;
             }
+
+            args[i++] = "-wildcards";
+            args[i++] = "-ef";
+            args[i++] = exclude_file;
         }
 
         args[i++] = 0;

--- a/appimagetool.c
+++ b/appimagetool.c
@@ -138,9 +138,6 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         args[i++] = "-root-owned";
         args[i++] = "-noappend";
 
-        // check if exclude file can be used
-        GString* ef = 0;
-
         if(use_xz) {
             // https://jonathancarter.org/2015/04/06/squashfs-performance-testing/ says:
             // improved performance by using a 16384 block size with a sacrifice of around 3% more squashfs image space

--- a/test-appimagetool.sh
+++ b/test-appimagetool.sh
@@ -22,15 +22,18 @@ trap cleanup EXIT
 cd "$tempdir"
 
 # create a sample AppDir
-mkdir appimagetool.AppDir
-cp -R "$thisdir"/resources/{appimagetool.*,AppRun} appimagetool.AppDir/
-cp -R "$appimagetool" appimagetool.AppDir/
+mkdir -p appimagetool.AppDir/usr/share/metainfo/
+cp "$thisdir"/resources/{appimagetool.*,AppRun} appimagetool.AppDir/
+cp "$thisdir"/resources/usr/share/metainfo/appimagetool.appdata.xml appimagetool.AppDir/usr/share/metainfo/
+cp "$appimagetool" appimagetool.AppDir/
+mkdir -p appimagetool.AppDir/usr/share/applications
+cp appimagetool.AppDir/appimagetool.desktop appimagetool.AppDir/usr/share/applications
 
 # create a file that should be ignored
 touch appimagetool.AppDir/to-be-ignored
 
 # create an AppImage without an ignore file to make sure it is bundled
-$appimagetool appimagetool.AppDir appimagetool.AppImage
+$appimagetool appimagetool.AppDir appimagetool.AppImage || exit $?
 $appimagetool -l appimagetool.AppImage | grep -q to-be-ignored || exit 1
 
 # now set up the ignore file, and check that the file is properly ignored
@@ -39,11 +42,11 @@ $appimagetool appimagetool.AppDir appimagetool.AppImage
 $appimagetool -l appimagetool.AppImage | grep -q to-be-ignored && exit 1 || true
 
 # check if disabling the ignore file feature works by passing an empty string as argument
-$appimagetool appimagetool.AppDir appimagetool.AppImage --exclude-file ""
+$appimagetool appimagetool.AppDir appimagetool.AppImage --exclude-file "" || exit $?
 $appimagetool -l appimagetool.AppImage | grep -q to-be-ignored || exit 1
 
 # remove the default ignore file, and check if an explicitly passed one works, too
 rm .appimageignore
 echo "to-be-ignored" > ignore
-$appimagetool appimagetool.AppDir appimagetool.AppImage --exclude-file ignore
+$appimagetool appimagetool.AppDir appimagetool.AppImage --exclude-file ignore || exit $?
 $appimagetool -l appimagetool.AppImage | grep -q to-be-ignored && exit 1 || true

--- a/test-appimagetool.sh
+++ b/test-appimagetool.sh
@@ -21,7 +21,9 @@ trap cleanup EXIT
 
 cd "$tempdir"
 
-# create a sample AppDir
+log() { echo "$(tput setaf 2)$(tput bold)$*$(tput sgr0)"; }
+
+log "create a sample AppDir"
 mkdir -p appimagetool.AppDir/usr/share/metainfo/
 cp "$thisdir"/resources/{appimagetool.*,AppRun} appimagetool.AppDir/
 cp "$thisdir"/resources/usr/share/metainfo/appimagetool.appdata.xml appimagetool.AppDir/usr/share/metainfo/
@@ -29,24 +31,27 @@ cp "$appimagetool" appimagetool.AppDir/
 mkdir -p appimagetool.AppDir/usr/share/applications
 cp appimagetool.AppDir/appimagetool.desktop appimagetool.AppDir/usr/share/applications
 
-# create a file that should be ignored
+log "create a file that should be ignored"
 touch appimagetool.AppDir/to-be-ignored
 
-# create an AppImage without an ignore file to make sure it is bundled
+log "create an AppImage without an ignore file to make sure it is bundled"
 $appimagetool appimagetool.AppDir appimagetool.AppImage || exit $?
 $appimagetool -l appimagetool.AppImage | grep -q to-be-ignored || exit 1
 
-# now set up the ignore file, and check that the file is properly ignored
+log "now set up the ignore file, and check that the file is properly ignored"
 echo "to-be-ignored" > .appimageignore
 $appimagetool appimagetool.AppDir appimagetool.AppImage
 $appimagetool -l appimagetool.AppImage | grep -q to-be-ignored && exit 1 || true
 
-# check if disabling the ignore file feature works by passing an empty string as argument
-$appimagetool appimagetool.AppDir appimagetool.AppImage --exclude-file "" || exit $?
-$appimagetool -l appimagetool.AppImage | grep -q to-be-ignored || exit 1
-
-# remove the default ignore file, and check if an explicitly passed one works, too
+log "remove the default ignore file, and check if an explicitly passed one works, too"
 rm .appimageignore
 echo "to-be-ignored" > ignore
 $appimagetool appimagetool.AppDir appimagetool.AppImage --exclude-file ignore || exit $?
 $appimagetool -l appimagetool.AppImage | grep -q to-be-ignored && exit 1 || true
+
+log "check whether files in both .appimageignore and the explicitly passed file work"
+touch appimagetool.AppDir/to-be-ignored-too
+echo "to-be-ignored-too" > .appimageignore
+$appimagetool appimagetool.AppDir appimagetool.AppImage --exclude-file ignore || exit $?
+$appimagetool -l appimagetool.AppImage | grep -q to-be-ignored && exit 1 || true
+$appimagetool -l appimagetool.AppImage | grep -q to-be-ignored-too && exit 1 || true


### PR DESCRIPTION
This way, the exclude file parameter specifies a file additional to .appimageignore, instead of replacing .appimageignore. Disabling the use of .appimageignore at all does no longer work, but that use case is not really of any use, so the removal won't hurt.