### PR TITLE
upload runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ compiler: gcc
 
 services:
   - docker
- 
+
 env:
   - ARCH=i686 DOCKER_IMAGE=toopher/centos-i386:centos6
   - ARCH=x86_64 DOCKER_IMAGE=library/centos:6.8
- 
+
 script:
   - if [ "$ARCH" == "x86_64" ] ; then sed -i -e 's|%ARCH%|amd64|g' appimaged.ctl; fi
   - if [ "$ARCH" == "i686" ] ; then sed -i -e 's|%ARCH%|i386|g' appimaged.ctl && sleep 60 ; fi # Slep so as not to overwrite during uploading (FIXME)
@@ -22,16 +22,16 @@ script:
   - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
   - find ./out/appimagetool.AppDir/
   - find ./out/appimaged.AppDir/
-  - docker run --cap-add SYS_ADMIN --device /dev/fuse:/dev/fuse:mrw -i -v ${PWD}/out:/out -v $HOME/.gnupg:/root/.gnupg "$DOCKER_IMAGE" /bin/bash -c 
-      "yum -y install fuse fuse-libs && 
-      cd /out && 
+  - docker run --cap-add SYS_ADMIN --device /dev/fuse:/dev/fuse:mrw -i -v ${PWD}/out:/out -v $HOME/.gnupg:/root/.gnupg "$DOCKER_IMAGE" /bin/bash -c
+      "yum -y install fuse fuse-libs &&
+      cd /out &&
       ./appimagetool.AppDir/AppRun ./appimagetool.AppDir/ -s -v -u \"zsync|https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$ARCH.AppImage.zsync\"
       appimagetool-$ARCH.AppImage &&
       ./appimagetool-$ARCH.AppImage ./appimaged.AppDir/ -s -v -u \"zsync|https://github.com/AppImage/AppImageKit/releases/download/continuous/appimaged-$ARCH.AppImage.zsync\" appimaged-$ARCH.AppImage"
   - sudo apt-get install equivs
   - ( cd out ; equivs-build ../appimaged.ctl )
   - rm -rf out/appimaged out/appimagetool out/validate out/digest out/mksquashfs || true
-  - rm -rf out/runtime || true # Not needed, might confuse users
+  - mv out/runtime out/runtime-$ARCH
   - sudo rm -rf out/*.AppDir out/*.AppImage.digest || true # Not needed
   - if [ "$ARCH" == "x86_64" ] ; then sudo mv out/AppRun out/AppRun-x86_64; fi
   - if [ "$ARCH" == "i686" ] ; then sudo mv out/AppRun out/AppRun-i686; fi
@@ -39,7 +39,7 @@ script:
 
 notifications:
   irc:
-    channels: 
+    channels:
       - "chat.freenode.net#AppImage"
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always


### PR DESCRIPTION
In the past was easy to extract runtime from provided appimagetool. But not now.

`runtime` is required for macOS `appimage` tool or for manual  creation of AppImage.

Example — https://github.com/develar/AppImageKit/releases/tag/continuous

Sorry that PR contains automatic cleanup (trailing spaces).