### PR TITLE
Add extra arguments when signing with gpg2

### DIFF
--- a/appimagetool.c
+++ b/appimagetool.c
@@ -796,7 +796,7 @@ main (int argc, char *argv[])
                     die(using_shasum ? "shasum command did not succeed" : "sha256sum command did not succeed");
                 if (g_file_test (ascfile, G_FILE_TEST_IS_REGULAR))
                     unlink(ascfile);
-                sprintf (command, "%s --detach-sign --armor %s %s", gpg2_path, sign_args ? sign_args : "\0", digestfile);
+                sprintf (command, "%s --detach-sign --armor %s %s", gpg2_path, sign_args ? sign_args : "", digestfile);
                 if(verbose)
                     fprintf (stderr, "%s\n", command);
                 fp = popen(command, "r");

--- a/appimagetool.c
+++ b/appimagetool.c
@@ -81,6 +81,7 @@ gchar *bintray_repo = NULL;
 gchar *sqfs_comp = "gzip";
 gchar *exclude_file = NULL;
 gchar *runtime_file = NULL;
+gchar *sign_args = NULL;
 
 // #####################################################################
 
@@ -412,6 +413,7 @@ static GOptionEntry entries[] =
     { "no-appstream", 'n', 0, G_OPTION_ARG_NONE, &no_appstream, "Do not check AppStream metadata", NULL },
     { "exclude-file", 0, 0, G_OPTION_ARG_STRING, &exclude_file, _exclude_file_desc, NULL },
     { "runtime-file", 0, 0, G_OPTION_ARG_STRING, &runtime_file, "Runtime file to use", NULL },
+    { "sign-args", 0, 0, G_OPTION_ARG_STRING, &sign_args, "Extra arguments to use when signing with gpg[2]", NULL},
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &remaining_args, NULL, NULL },
     { 0,0,0,0,0,0,0 }
 };
@@ -794,7 +796,7 @@ main (int argc, char *argv[])
                     die(using_shasum ? "shasum command did not succeed" : "sha256sum command did not succeed");
                 if (g_file_test (ascfile, G_FILE_TEST_IS_REGULAR))
                     unlink(ascfile);
-                sprintf (command, "%s --detach-sign --armor %s", gpg2_path, digestfile);
+                sprintf (command, "%s --detach-sign --armor %s %s", gpg2_path, sign_args ? sign_args : "\0", digestfile);
                 if(verbose)
                     fprintf (stderr, "%s\n", command);
                 fp = popen(command, "r");


### PR DESCRIPTION
This is needed in case you need to pass to gpg2 useful parameters such as passphrase, homedir, etc.

The workaround for this is both tricky and ugly: create a wrapper for gpg2 and append its path to the $PATH env variable so that it's the one used by appimagetool. e.g. ~/gpg2 containing:

> #!/bin/bash
>$GPG2_PATH -my -own -args $1 $2 $3 $4...

The change is quite straightforward and pretty simple. The name for the parameter can be changed if needed.