### PR TITLE
Implement proper version information in tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,26 @@ include(CTest)
 # build information #
 #####################
 
+# determine Git commit ID
 execute_process(
     COMMAND git describe --tags --always --abbrev=7
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# set version and build number
+set(VERSION 1-alpha)
+if("$ENV{TRAVIS_BUILD_NUMBER}" STREQUAL "")
+    set(BUILD_NUMBER "<local dev build>")
+else()
+    set(BUILD_NUMBER "$ENV{TRAVIS_BUILD_NUMBER}")
+endif()
+
+# get current date
+execute_process(
+    COMMAND env LC_ALL=C date -u "+%Y-%m-%d %H:%M:%S %Z"
+    OUTPUT_VARIABLE DATE
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,7 +118,10 @@ target_link_libraries(appimaged
 )
 
 target_compile_definitions(appimaged
-    PRIVATE -DVERSION_NUMBER="${GIT_VERSION}"
+    PRIVATE -DGIT_COMMIT="${GIT_COMMIT}"
+    PRIVATE -DVERSION_NUMBER="${GIT_COMMIT}"  # legacy variable
+    PRIVATE -DBUILD_NUMBER="${BUILD_NUMBER}"
+    PRIVATE -DBUILD_DATE="${DATE}"
     PRIVATE -D_FILE_OFFSET_BITS=64
     PRIVATE -DHAVE_LIBARCHIVE3=0
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,9 @@ target_link_libraries(appimagetool
 
 target_compile_definitions(appimagetool
     PRIVATE -D_FILE_OFFSET_BITS=64
-    PRIVATE -DVERSION_NUMBER="${GIT_VERSION}"
+    PRIVATE -DGIT_COMMIT="${GIT_COMMIT}"
+    PRIVATE -DBUILD_NUMBER="${BUILD_NUMBER}"
+    PRIVATE -DBUILD_DATE="${DATE}"
     PRIVATE -DENABLE_BINRELOC
 )
 

--- a/src/appimaged.c
+++ b/src/appimaged.c
@@ -55,10 +55,14 @@
 
 #include <pthread.h>
 
+#ifndef RELEASE_NAME
+    #define RELEASE_NAME "continuous build"
+#endif
+
 extern int notify(char *title, char *body, int timeout);
 
 static gboolean verbose = FALSE;
-static gboolean version = FALSE;
+static gboolean showVersionOnly = FALSE;
 static gboolean install = FALSE;
 static gboolean uninstall = FALSE;
 gchar **remaining_args = NULL;
@@ -68,7 +72,7 @@ static GOptionEntry entries[] =
     { "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose, "Be verbose", NULL },
     { "install", 'i', 0, G_OPTION_ARG_NONE, &install, "Install this appimaged instance to $HOME", NULL },
     { "uninstall", 'u', 0, G_OPTION_ARG_NONE, &uninstall, "Uninstall an appimaged instance from $HOME", NULL },
-    { "version", 0, 0, G_OPTION_ARG_NONE, &version, "Show version number", NULL },
+    { "version", 0, 0, G_OPTION_ARG_NONE, &showVersionOnly, "Show version number", NULL },
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &remaining_args, NULL },
     { NULL }
 };
@@ -226,12 +230,17 @@ int main(int argc, char ** argv) {
         exit (1);
     }
 
-    if(version){
-        fprintf(stderr,"Version: %s\n", VERSION_NUMBER);
-        exit(0);
-    }
+    // always show version, but exit immediately if only the version number was requested
+    fprintf(
+        stderr,
+        "appimaged, %s (commit %s), build %s built on %s\n",
+        RELEASE_NAME, GIT_COMMIT, BUILD_NUMBER, BUILD_DATE
+    );
 
-    if ( !inotifytools_initialize()){
+    if(showVersionOnly)
+        exit(0);
+
+    if (!inotifytools_initialize()) {
         fprintf(stderr, "inotifytools_initialize error\n");
         exit(1);
     }

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -26,6 +26,10 @@
 
 #ident "AppImage by Simon Peter, http://appimage.org/"
 
+#ifndef RELEASE_NAME
+    #define RELEASE_NAME "continuous build"
+#endif
+
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <stdlib.h>
@@ -71,7 +75,7 @@ static char _exclude_file_desc[256];
 
 static gboolean list = FALSE;
 static gboolean verbose = FALSE;
-static gboolean version = FALSE;
+static gboolean showVersionOnly = FALSE;
 static gboolean sign = FALSE;
 static gboolean no_appstream = FALSE;
 gchar **remaining_args = NULL;
@@ -407,7 +411,7 @@ static GOptionEntry entries[] =
     { "guess", 'g', 0, G_OPTION_ARG_NONE, &guessupdateinformation, "Guess update information based on Travis CI environment variables", NULL },
     { "bintray-user", 0, 0, G_OPTION_ARG_STRING, &bintray_user, "Bintray user name", NULL },
     { "bintray-repo", 0, 0, G_OPTION_ARG_STRING, &bintray_repo, "Bintray repository", NULL },
-    { "version", 0, 0, G_OPTION_ARG_NONE, &version, "Show version number", NULL },
+    { "version", 0, 0, G_OPTION_ARG_NONE, &showVersionOnly, "Show version number", NULL },
     { "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose, "Produce verbose output", NULL },
     { "sign", 's', 0, G_OPTION_ARG_NONE, &sign, "Sign with gpg[2]", NULL },
     { "comp", 0, 0, G_OPTION_ARG_STRING, &sqfs_comp, "Squashfs compression", NULL },
@@ -474,10 +478,14 @@ main (int argc, char *argv[])
         exit(1);
     }
 
-    if(version){
-        fprintf(stderr,"Version: %s\n", VERSION_NUMBER);
+    fprintf(
+        stderr,"appimagetool, %s (commit %s), build %s built on %s\n",
+        RELEASE_NAME, GIT_COMMIT, BUILD_NUMBER, BUILD_DATE
+    );
+
+    // always show version, but exit immediately if only the version number was requested
+    if (showVersionOnly)
         exit(0);
-    }
 
     if(!((0 == strcmp(sqfs_comp, "gzip")) || (0 ==strcmp(sqfs_comp, "xz"))))
         die("Only gzip (faster execution, larger files) and xz (slower execution, smaller files) compression is supported at the moment. Let us know if there are reasons for more, should be easy to add. You could help the project by doing some systematic size/performance measurements. Watch for size, execution speed, and zsync delta size.");

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -479,7 +479,8 @@ main (int argc, char *argv[])
     }
 
     fprintf(
-        stderr,"appimagetool, %s (commit %s), build %s built on %s\n",
+        stderr,
+        "appimagetool, %s (commit %s), build %s built on %s\n",
         RELEASE_NAME, GIT_COMMIT, BUILD_NUMBER, BUILD_DATE
     );
 


### PR DESCRIPTION
This is a proposal to add proper version information to the tools we supply.

As the tools are forced to always have the same name to have a static URL for the binaries that users can rely on in builds etc., we always have a little problem seeing what version of the tools the users use.

This PR:

a) implements proper version information (release name, Git commit ID, Travis build number, build date) that allows for uniquely identifying every binary ever shipped
b) adds CMake code generating the required information and passing it to the build

What's missing is the `build.sh` implementation (I hope for @probonopd to integrate that at the appropriate places).

Furthermore, I'd vote for integrating those code snippets into appimaged and the rest, too. But adding this to appimagetool is a big step forward already.