### PR TITLE
Add appimage-portable options for home and config

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -207,7 +207,7 @@ mkdir_p(const char *path)
 void
 print_help()
 {
-// TODO:   "--appimage-list                 List content from embedded filesystem image\n"
+    // TODO: "--appimage-list                 List content from embedded filesystem image\n"
     printf(
         "AppImage options:\n\n"
         "  --appimage-extract              Extract content from embedded filesystem image\n"
@@ -223,7 +223,7 @@ print_help()
         "  --appimage-version              Print version of AppImageKit\n"
         "\n"
         "Portable options:\n"
-	"\n"
+        "\n"
         "  If you want the AppImage to use a portable $HOME or $XDG_CONFIG_HOME, you can\n"
         "  use the --appimage-portable options or create the following directories manually:\n"
         "\n"

--- a/runtime.c
+++ b/runtime.c
@@ -209,15 +209,22 @@ print_help()
 {
 // TODO:   "--appimage-list                 List content from embedded filesystem image\n"
     printf("AppImage options:\n\n"
-           "--appimage-extract              Extract content from embedded filesystem image\n"
-           "--appimage-help                 Print this help\n"
-           "--appimage-mount                Mount embedded filesystem image and\n"
-           "                                print mount point and wait for kill with Ctrl-C\n"
-           "--appimage-offset               Print byte offset to start of\n"
-           "                                embedded filesystem image\n"
-           "--appimage-signature            Print digital signature embedded in AppImage\n"
-           "--appimage-updateinfo[rmation]  Print update info embedded in AppImage\n"
-           "--appimage-version              Print version of AppImageKit\n"
+           "  --appimage-extract              Extract content from embedded filesystem image\n"
+           "  --appimage-help                 Print this help\n"
+           "  --appimage-mount                Mount embedded filesystem image and\n"
+           "                                  print mount point and wait for kill with Ctrl-C\n"
+           "  --appimage-offset               Print byte offset to start of\n"
+           "                                  embedded filesystem image\n"
+           "  --appimage-portable-home        Create a portable home folder to use as $HOME\n"
+           "  --appimage-portable-config      Create a portable config folder to use as $XDG_CONFIG_HOME\n"
+           "  --appimage-signature            Print digital signature embedded in AppImage\n"
+           "  --appimage-updateinfo[rmation]  Print update info embedded in AppImage\n"
+           "  --appimage-version              Print version of AppImageKit\n\n"
+           "Portable options:\n\n"
+           "  If you want the AppImage to use a portable $HOME or $XDG_CONFIG_HOME, you can\n"
+           "  use the --appimage-portable options or create the following folders manually:\n\n"
+           "    My.AppImage.home will be used as $HOME\n"
+           "    My.AppImage.config will be used as $XDG_CONFIG_HOME\n"
            );
 }
 
@@ -382,6 +389,38 @@ main (int argc, char *argv[])
         // printf("length: %lu\n", length);
         // print_hex(appimage_path, offset, length);
         print_binary(appimage_path, offset, length);
+        exit(0);
+    }
+
+    if (arg && strcmp(arg,"appimage-portable-home")==0) {
+        char portable_home[2048];
+        int mkdir_ret;
+
+        sprintf(portable_home, "%s.home", appimage_path);
+        mkdir_ret = mkdir(portable_home, S_IRWXU);
+        if (mkdir_ret == 0)
+            printf("Portable home folder created at %s\n", portable_home);
+        else if (mkdir_ret == EEXIST)
+            printf("Portable home folder %s already exists\n", portable_home);
+        else
+            printf("Error creating portable home folder at %s: %s\n", portable_home, strerror(errno));
+
+        exit(0);
+    }
+
+    if (arg && strcmp(arg,"appimage-portable-config")==0) {
+        char portable_config[2048];
+        int mkdir_ret;
+
+        sprintf(portable_config, "%s.config", appimage_path);
+        mkdir_ret = mkdir(portable_config, S_IRWXU);
+        if (mkdir_ret == 0)
+            printf("Portable config folder created at %s\n", portable_config);
+        else if (mkdir_ret == EEXIST)
+            printf("Portable config folder %s already exists\n", portable_config);
+        else
+            printf("Error creating portable config folder at %s: %s\n", portable_config, strerror(errno));
+
         exit(0);
     }
 

--- a/runtime.c
+++ b/runtime.c
@@ -393,7 +393,7 @@ main (int argc, char *argv[])
     }
 
     if (arg && strcmp(arg,"appimage-portable-home")==0) {
-        char portable_home[2048];
+        char portable_home[PATH_MAX];
         int mkdir_ret;
 
         sprintf(portable_home, "%s.home", appimage_path);
@@ -415,7 +415,7 @@ main (int argc, char *argv[])
     }
 
     if (arg && strcmp(arg,"appimage-portable-config")==0) {
-        char portable_config[2048];
+        char portable_config[PATH_MAX];
         int mkdir_ret;
 
         sprintf(portable_config, "%s.config", appimage_path);
@@ -561,8 +561,8 @@ main (int argc, char *argv[])
 	setenv( "ARGV0", argv0_path, 1 );
         setenv( "APPDIR", mount_dir, 1 );
 
-        char portable_home_dir[2048];
-        char portable_config_dir[2048];
+        char portable_home_dir[PATH_MAX];
+        char portable_config_dir[PATH_MAX];
         
         /* If there is a directory with the same name as the AppImage plus ".home", then export $HOME */
         strcpy (portable_home_dir, fullpath);

--- a/runtime.c
+++ b/runtime.c
@@ -208,26 +208,28 @@ void
 print_help()
 {
 // TODO:   "--appimage-list                 List content from embedded filesystem image\n"
-    printf("AppImage options:\n\n"
-           "  --appimage-extract              Extract content from embedded filesystem image\n"
-           "  --appimage-help                 Print this help\n"
-           "  --appimage-mount                Mount embedded filesystem image and\n"
-           "                                  print mount point and wait for kill with Ctrl-C\n"
-           "  --appimage-offset               Print byte offset to start of\n"
-           "                                  embedded filesystem image\n"
-           "  --appimage-portable-home        Create a portable home folder to use as $HOME\n"
-           "  --appimage-portable-config      Create a portable config folder to use as $XDG_CONFIG_HOME\n"
-           "  --appimage-signature            Print digital signature embedded in AppImage\n"
-           "  --appimage-updateinfo[rmation]  Print update info embedded in AppImage\n"
-           "  --appimage-version              Print version of AppImageKit\n\n"
-           ""
-           "Portable options:\n\n"
-           "  If you want the AppImage to use a portable $HOME or $XDG_CONFIG_HOME, you can\n"
-           "  use the --appimage-portable options or create the following directories manually:\n"
-           "\n"
-           "  My.AppImage.home will be used as $HOME\n"
-           "  My.AppImage.config will be used as $XDG_CONFIG_HOME\n"
-           );
+    printf(
+        "AppImage options:\n\n"
+        "  --appimage-extract              Extract content from embedded filesystem image\n"
+        "  --appimage-help                 Print this help\n"
+        "  --appimage-mount                Mount embedded filesystem image and\n"
+        "                                  print mount point and wait for kill with Ctrl-C\n"
+        "  --appimage-offset               Print byte offset to start of\n"
+        "                                  embedded filesystem image\n"
+        "  --appimage-portable-home        Create a portable home folder to use as $HOME\n"
+        "  --appimage-portable-config      Create a portable config folder to use as $XDG_CONFIG_HOME\n"
+        "  --appimage-signature            Print digital signature embedded in AppImage\n"
+        "  --appimage-updateinfo[rmation]  Print update info embedded in AppImage\n"
+        "  --appimage-version              Print version of AppImageKit\n"
+        "\n"
+        "Portable options:\n"
+	"\n"
+        "  If you want the AppImage to use a portable $HOME or $XDG_CONFIG_HOME, you can\n"
+        "  use the --appimage-portable options or create the following directories manually:\n"
+        "\n"
+        "  My.AppImage.home will be used as $HOME\n"
+        "  My.AppImage.config will be used as $XDG_CONFIG_HOME\n"
+    );
 }
 
 int

--- a/runtime.c
+++ b/runtime.c
@@ -222,7 +222,7 @@ print_help()
            "  --appimage-version              Print version of AppImageKit\n\n"
            "Portable options:\n\n"
            "  If you want the AppImage to use a portable $HOME or $XDG_CONFIG_HOME, you can\n"
-           "  use the --appimage-portable options or create the following folders manually:\n\n"
+           "  use the --appimage-portable options or create the following directories manually:\n\n"
            "    My.AppImage.home will be used as $HOME\n"
            "    My.AppImage.config will be used as $XDG_CONFIG_HOME\n"
            );
@@ -398,12 +398,18 @@ main (int argc, char *argv[])
 
         sprintf(portable_home, "%s.home", appimage_path);
         mkdir_ret = mkdir(portable_home, S_IRWXU);
-        if (mkdir_ret == 0)
-            printf("Portable home folder created at %s\n", portable_home);
-        else if (mkdir_ret == EEXIST)
-            printf("Portable home folder %s already exists\n", portable_home);
-        else
-            printf("Error creating portable home folder at %s: %s\n", portable_home, strerror(errno));
+
+        switch (mkdir_ret) {
+            case 0:
+                printf("Portable home directory created at %s\n", portable_home);
+                break;
+            case EEXIST:
+                printf("Portable home directory %s already exists\n", portable_home);
+                break;
+            default:
+                printf("Error creating portable home directory at %s: %s\n", portable_home, strerror(errno));
+                break;
+        }
 
         exit(0);
     }
@@ -414,12 +420,18 @@ main (int argc, char *argv[])
 
         sprintf(portable_config, "%s.config", appimage_path);
         mkdir_ret = mkdir(portable_config, S_IRWXU);
-        if (mkdir_ret == 0)
-            printf("Portable config folder created at %s\n", portable_config);
-        else if (mkdir_ret == EEXIST)
-            printf("Portable config folder %s already exists\n", portable_config);
-        else
-            printf("Error creating portable config folder at %s: %s\n", portable_config, strerror(errno));
+
+        switch (mkdir_ret) {
+            case 0:
+                printf("Portable config directory created at %s\n", portable_config);
+                break;
+            case EEXIST:
+                printf("Portable config directory %s already exists\n", portable_config);
+                break;
+            default:
+                printf("Error creating portable config directory at %s: %s\n", portable_config, strerror(errno));
+                break;
+        }
 
         exit(0);
     }

--- a/runtime.c
+++ b/runtime.c
@@ -220,11 +220,13 @@ print_help()
            "  --appimage-signature            Print digital signature embedded in AppImage\n"
            "  --appimage-updateinfo[rmation]  Print update info embedded in AppImage\n"
            "  --appimage-version              Print version of AppImageKit\n\n"
+           ""
            "Portable options:\n\n"
            "  If you want the AppImage to use a portable $HOME or $XDG_CONFIG_HOME, you can\n"
            "  use the --appimage-portable options or create the following directories manually:\n\n"
-           "    My.AppImage.home will be used as $HOME\n"
-           "    My.AppImage.config will be used as $XDG_CONFIG_HOME\n"
+           ""
+           "  My.AppImage.home will be used as $HOME\n"
+           "  My.AppImage.config will be used as $XDG_CONFIG_HOME\n"
            );
 }
 
@@ -394,12 +396,9 @@ main (int argc, char *argv[])
 
     if (arg && strcmp(arg,"appimage-portable-home")==0) {
         char portable_home[PATH_MAX];
-        int mkdir_ret;
 
         sprintf(portable_home, "%s.home", appimage_path);
-        mkdir_ret = mkdir(portable_home, S_IRWXU);
-
-        switch (mkdir_ret) {
+        switch (mkdir(portable_home, S_IRWXU)) {
             case 0:
                 printf("Portable home directory created at %s\n", portable_home);
                 break;
@@ -410,18 +409,14 @@ main (int argc, char *argv[])
                 printf("Error creating portable home directory at %s: %s\n", portable_home, strerror(errno));
                 break;
         }
-
         exit(0);
     }
 
     if (arg && strcmp(arg,"appimage-portable-config")==0) {
         char portable_config[PATH_MAX];
-        int mkdir_ret;
 
         sprintf(portable_config, "%s.config", appimage_path);
-        mkdir_ret = mkdir(portable_config, S_IRWXU);
-
-        switch (mkdir_ret) {
+        switch (mkdir(portable_config, S_IRWXU)) {
             case 0:
                 printf("Portable config directory created at %s\n", portable_config);
                 break;
@@ -432,7 +427,6 @@ main (int argc, char *argv[])
                 printf("Error creating portable config directory at %s: %s\n", portable_config, strerror(errno));
                 break;
         }
-
         exit(0);
     }
 

--- a/runtime.c
+++ b/runtime.c
@@ -223,8 +223,8 @@ print_help()
            ""
            "Portable options:\n\n"
            "  If you want the AppImage to use a portable $HOME or $XDG_CONFIG_HOME, you can\n"
-           "  use the --appimage-portable options or create the following directories manually:\n\n"
-           ""
+           "  use the --appimage-portable options or create the following directories manually:\n"
+           "\n"
            "  My.AppImage.home will be used as $HOME\n"
            "  My.AppImage.config will be used as $XDG_CONFIG_HOME\n"
            );


### PR DESCRIPTION
This is a PR as requested in https://github.com/AppImage/AppImageKit/pull/526#issuecomment-345435453 to add to the help information regarding the portable options.

It also adds the following two options:
- --appimage-portable-home which will create My.AppImage.home if it does not exist
- --appimage-portable-config which will create My.AppImage.config if it does not exist
