### PR TITLE
Pad runtime to multiple of 512 bytes

### DIFF
--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -72,6 +72,9 @@ printf '\x41\x49\x02' | dd of=runtime bs=1 seek=8 count=3 conv=notrunc
 # Convert runtime into a data object that can be embedded into appimagetool
 ld -r -b binary -o data.o runtime
 
+# Pad runtime to multiple of 512bytes
+dd if=/dev/null of=runtime bs=1 count=1 seek=$(./runtime --appimage-offset)
+
 # Show header for debugging purposes
 xxd runtime | head -n 1
 

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -71,9 +71,6 @@ APPIMAGEOFFSET=$(./runtime --appimage-offset)
 # Insert AppImage magic bytes
 printf '\x41\x49\x02' | dd of=runtime bs=1 seek=8 count=3 conv=notrunc
 
-# Convert runtime into a data object that can be embedded into appimagetool
-ld -r -b binary -o data.o runtime
-
 # Pad runtime to multiple of 512bytes
 dd if=/dev/null of=runtime bs=1 count=1 seek=$APPIMAGEOFFSET
 
@@ -82,6 +79,9 @@ printf '\x55\xaa' | dd of=runtime bs=1 seek=510 count=2 conv=notrunc
 
 # Add partition entry to runtime, this way gnome-disk-image-mounter can open it.
 printf "0x%08x" $(echo $APPIMAGEOFFSET / 512 | bc) | xxd -r | tac -rs. | dd of=runtime bs=1 seek=454 count=4 conv=notrunc
+
+# Convert runtime into a data object that can be embedded into appimagetool
+ld -r -b binary -o data.o runtime
 
 # Show header for debugging purposes
 xxd runtime | head -n 1

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -75,6 +75,12 @@ ld -r -b binary -o data.o runtime
 # Pad runtime to multiple of 512bytes
 dd if=/dev/null of=runtime bs=1 count=1 seek=$(./runtime --appimage-offset)
 
+# Add boot signature to runtime, this way fdisk recognize the appimage as a partitioned disk image
+printf '\x55\xaa' | dd of=runtime bs=1 seek=510 count=2 conv=notrunc
+
+# Add partition entry to runtime, this way gnome-disk-image-mounter can open it.
+printf "0x%08x" $(( $(./runtime --appimage-offset) / 512 )) | xxd -r | tac -rs. | dd of=runtime bs=1 seek=454 count=4 conv=notrunc
+
 # Show header for debugging purposes
 xxd runtime | head -n 1
 

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -78,7 +78,7 @@ dd if=/dev/null of=runtime bs=1 count=1 seek=$APPIMAGEOFFSET
 printf '\x55\xaa' | dd of=runtime bs=1 seek=510 count=2 conv=notrunc
 
 # Add partition entry to runtime, this way gnome-disk-image-mounter can open it.
-printf "0x%08x" $(echo $APPIMAGEOFFSET / 512 | bc) | xxd -r | tac -rs. | dd of=runtime bs=1 seek=454 count=4 conv=notrunc
+printf "0x%08x" $((APPIMAGEOFFSET / 512 )) | xxd -r | tac -rs. | dd of=runtime bs=1 seek=454 count=4 conv=notrunc
 
 # Convert runtime into a data object that can be embedded into appimagetool
 ld -r -b binary -o data.o runtime

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -66,6 +66,8 @@ HEXOFFSET=$(objdump -h runtime | grep .upd_info | awk '{print $6}')
 HEXLENGTH=$(objdump -h runtime | grep .upd_info | awk '{print $3}')
 dd bs=1 if=runtime skip=$(($(echo 0x$HEXOFFSET)+0)) count=$(($(echo 0x$HEXLENGTH)+0)) | xxd
 
+APPIMAGEOFFSET=$(./runtime --appimage-offset)
+
 # Insert AppImage magic bytes
 printf '\x41\x49\x02' | dd of=runtime bs=1 seek=8 count=3 conv=notrunc
 
@@ -73,13 +75,13 @@ printf '\x41\x49\x02' | dd of=runtime bs=1 seek=8 count=3 conv=notrunc
 ld -r -b binary -o data.o runtime
 
 # Pad runtime to multiple of 512bytes
-dd if=/dev/null of=runtime bs=1 count=1 seek=$(./runtime --appimage-offset)
+dd if=/dev/null of=runtime bs=1 count=1 seek=$APPIMAGEOFFSET
 
 # Add boot signature to runtime, this way fdisk recognize the appimage as a partitioned disk image
 printf '\x55\xaa' | dd of=runtime bs=1 seek=510 count=2 conv=notrunc
 
 # Add partition entry to runtime, this way gnome-disk-image-mounter can open it.
-printf "0x%08x" $(( $(./runtime --appimage-offset) / 512 )) | xxd -r | tac -rs. | dd of=runtime bs=1 seek=454 count=4 conv=notrunc
+printf "0x%08x" $(echo $APPIMAGEOFFSET / 512 | bc) | xxd -r | tac -rs. | dd of=runtime bs=1 seek=454 count=4 conv=notrunc
 
 # Show header for debugging purposes
 xxd runtime | head -n 1

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -289,7 +289,9 @@ main (int argc, char *argv[])
     sprintf(argv0_path, argv[0]);
 
     fs_offset = get_elf_size(appimage_path);
-    
+    /*It's better to keep filesystems aligned at 512bytes intervals, like sectors on a real partitioned disk*/
+    fs_offset = ((fs_offset-1)|511)+1;
+
     arg=getArg(argc,argv,'-');
 
     /* Print the help and then exit */


### PR DESCRIPTION
If the squashfs filesystem starts at a multiple of 512bytes offset
it is possible to replace the runtime (using fdisk) or possibly
inject it (using dd) with a dos partition table at offset 446,
similarly to how the 3 AppImage magic bytes are inserted at offset 8
(the partition table is only 64bytes long, and not all of those are
actually needed)

This way the appimage can be mounted by existing tools like gnome-disk-image-mounter
which reads from the partition table the offset of the filesystem

Now if someone finds a way to fit a valid partition table inside an elf binary we could reach the holy grail of an appimage that can be both executed and easily mounted.