### PR TITLE
Fix wrong 'if' condition on build.sh always running tests.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_T
 make -j$JOBS
 make install DESTDIR=install_prefix/
 
-if [ $RUN_TESTS -gt 0 ]; then
+if [ $RUN_TESTS -ne 0 ]; then
   ctest -V
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_T
 make -j$JOBS
 make install DESTDIR=install_prefix/
 
-if [ ! -z $RUN_TESTS ]; then
+if [ $RUN_TESTS -gt 0 ]; then
   ctest -V
 fi
 


### PR DESCRIPTION
The build.sh script always runs tests even when the --run-tests flag is not used.