### PR TITLE
Auto-start the appimaged service after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Or, if you are on a deb-based system:
 ```
 wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimaged_1.0_amd64.deb"
 sudo dpkg -i appimaged_*.deb
-systemctl --user enable appimaged
+systemctl --user add-wants default.target appimaged
 systemctl --user start appimaged
 ```
 


### PR DESCRIPTION
In OS Ubuntu 17.10 the appimaged service no auto-start.
It is need to add the appimaged service to default.target.
After it the appimaged service begin to auto-start.