### PR TITLE
dependencies: Skip SSL verification

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -128,8 +128,8 @@ if(NOT USE_SYSTEM_INOTIFY_TOOLS)
     ExternalProject_Add(inotify-tools
         URL https://github.com/downloads/rvoicilas/inotify-tools/inotify-tools-3.14.tar.gz
         URL_HASH SHA512=6074d510e89bba5da0d7c4d86f2562c662868666ba0a7ea5d73e53c010a0050dd1fc01959b22cffdb9b8a35bd1b0b43c04d02d6f19927520f05889e8a9297dfb
-        PATCH_COMMAND wget -N --content-disposition "https://git.savannah.gnu.org/gitweb/?p=config.git$<SEMICOLON>a=blob_plain$<SEMICOLON>f=config.guess$<SEMICOLON>hb=HEAD"
-              COMMAND wget -N --content-disposition "https://git.savannah.gnu.org/gitweb/?p=config.git$<SEMICOLON>a=blob_plain$<SEMICOLON>f=config.sub$<SEMICOLON>hb=HEAD"
+        PATCH_COMMAND wget -N --no-check-certificate --content-disposition "https://git.savannah.gnu.org/gitweb/?p=config.git$<SEMICOLON>a=blob_plain$<SEMICOLON>f=config.guess$<SEMICOLON>hb=HEAD"
+              COMMAND wget -N --no-check-certificate --content-disposition "https://git.savannah.gnu.org/gitweb/?p=config.git$<SEMICOLON>a=blob_plain$<SEMICOLON>f=config.sub$<SEMICOLON>hb=HEAD"
         UPDATE_COMMAND ""  # make sure CMake won't try to fetch updates unnecessarily and hence rebuild the dependency every time
         CONFIGURE_COMMAND <SOURCE_DIR>/configure --enable-shared --enable-static --enable-doxygen=no --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/lib
         BUILD_COMMAND make


### PR DESCRIPTION
This works around the following problem on Ubuntu Xenial with Let's Encrypt:

[ 20%] Performing patch step for 'inotify-tools'
--2018-02-14 13:43:08--  https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
Resolving git.savannah.gnu.org (git.savannah.gnu.org)... 208.118.235.201
Connecting to git.savannah.gnu.org (git.savannah.gnu.org)|208.118.235.201|:443... connected.
ERROR: cannot verify git.savannah.gnu.org's certificate, issued by 'CN=Let\'s Encrypt Authority X3,O=Let\'s Encrypt,C=US':
  Unable to locally verify the issuer's authority.
To connect to git.savannah.gnu.org insecurely, use `--no-check-certificate'.