### PR TITLE
Make whitespace consistent

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -1,20 +1,20 @@
 /**************************************************************************
- * 
+ *
  * Copyright (c) 2004-18 Simon Peter
  * Portions Copyright (c) 2007 Alexander Larsson
- * 
+ *
  * All Rights Reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,7 +22,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- * 
+ *
  **************************************************************************/
 
 #ident "AppImage by Simon Peter, http://appimage.org/"
@@ -73,7 +73,7 @@ bool is_writable_directory(char* str) {
     if(access(str, W_OK) == 0) {
         return true;
     } else {
-        return false;   
+        return false;
     }
 }
 
@@ -86,37 +86,37 @@ bool startsWith(const char *pre, const char *str)
 
 /* Fill in a stat structure. Does not set st_ino */
 sqfs_err private_sqfs_stat(sqfs *fs, sqfs_inode *inode, struct stat *st) {
-	sqfs_err err = SQFS_OK;
-	uid_t id;
-	
-	memset(st, 0, sizeof(*st));
-	st->st_mode = inode->base.mode;
-	st->st_nlink = inode->nlink;
-	st->st_mtime = st->st_ctime = st->st_atime = inode->base.mtime;
-	
-	if (S_ISREG(st->st_mode)) {
-		/* FIXME: do symlinks, dirs, etc have a size? */
-		st->st_size = inode->xtra.reg.file_size;
-		st->st_blocks = st->st_size / 512;
-	} else if (S_ISBLK(st->st_mode) || S_ISCHR(st->st_mode)) {
-		st->st_rdev = sqfs_makedev(inode->xtra.dev.major,
-			inode->xtra.dev.minor);
-	} else if (S_ISLNK(st->st_mode)) {
-		st->st_size = inode->xtra.symlink_size;
-	}
-	
-	st->st_blksize = fs->sb.block_size; /* seriously? */
-	
-	err = sqfs_id_get(fs, inode->base.uid, &id);
-	if (err)
-		return err;
-	st->st_uid = id;
-	err = sqfs_id_get(fs, inode->base.guid, &id);
-	st->st_gid = id;
-	if (err)
-		return err;
-	
-	return SQFS_OK;
+        sqfs_err err = SQFS_OK;
+        uid_t id;
+
+        memset(st, 0, sizeof(*st));
+        st->st_mode = inode->base.mode;
+        st->st_nlink = inode->nlink;
+        st->st_mtime = st->st_ctime = st->st_atime = inode->base.mtime;
+
+        if (S_ISREG(st->st_mode)) {
+                /* FIXME: do symlinks, dirs, etc have a size? */
+                st->st_size = inode->xtra.reg.file_size;
+                st->st_blocks = st->st_size / 512;
+        } else if (S_ISBLK(st->st_mode) || S_ISCHR(st->st_mode)) {
+                st->st_rdev = sqfs_makedev(inode->xtra.dev.major,
+                        inode->xtra.dev.minor);
+        } else if (S_ISLNK(st->st_mode)) {
+                st->st_size = inode->xtra.symlink_size;
+        }
+
+        st->st_blksize = fs->sb.block_size; /* seriously? */
+
+        err = sqfs_id_get(fs, inode->base.uid, &id);
+        if (err)
+                return err;
+        st->st_uid = id;
+        err = sqfs_id_get(fs, inode->base.guid, &id);
+        st->st_gid = id;
+        if (err)
+                return err;
+
+        return SQFS_OK;
 }
 
 /* ================= End ELF parsing */
@@ -170,15 +170,15 @@ mkdir_p(const char *path)
     /* Adapted from http://stackoverflow.com/a/2336245/119527 */
     const size_t len = strlen(path);
     char _path[PATH_MAX];
-    char *p; 
+    char *p;
 
     errno = 0;
 
     /* Copy string so its mutable */
     if (len > sizeof(_path)-1) {
         errno = ENAMETOOLONG;
-        return -1; 
-    }   
+        return -1;
+    }
     strcpy(_path, path);
 
     /* Iterate the string */
@@ -189,17 +189,17 @@ mkdir_p(const char *path)
 
             if (mkdir(_path, S_IRWXU) != 0) {
                 if (errno != EEXIST)
-                    return -1; 
+                    return -1;
             }
 
             *p = '/';
         }
-    }   
+    }
 
     if (mkdir(_path, S_IRWXU) != 0) {
         if (errno != EEXIST)
-            return -1; 
-    }   
+            return -1;
+    }
 
     return 0;
 }
@@ -272,10 +272,10 @@ main (int argc, char *argv[])
     char appimage_path[PATH_MAX];
     char argv0_path[PATH_MAX];
     char * arg;
-    
+
     /* We might want to operate on a target appimage rather than this file itself,
      * e.g., for appimaged which must not run untrusted code from random AppImages.
-     * This variable is intended for use by e.g., appimaged and is subject to 
+     * This variable is intended for use by e.g., appimaged and is subject to
      * change any time. Do not rely on it being present. We might even limit this
      * functionality specifically for builds used by appimaged.
      */
@@ -285,11 +285,11 @@ main (int argc, char *argv[])
         sprintf(appimage_path, "%s", getenv("TARGET_APPIMAGE"));
         fprintf(stderr, "Using TARGET_APPIMAGE %s\n", appimage_path);
     }
-	
+
     sprintf(argv0_path, argv[0]);
 
     fs_offset = get_elf_size(appimage_path);
-    
+
     arg=getArg(argc,argv,'-');
 
     /* Print the help and then exit */
@@ -312,7 +312,7 @@ main (int argc, char *argv[])
         printf("%lu\n", fs_offset);
         exit(0);
     }
-    
+
     /* Exract the AppImage */
     arg=getArg(argc,argv,'-');
     if(arg && strcmp(arg,"appimage-extract")==0) {
@@ -322,24 +322,24 @@ main (int argc, char *argv[])
         char *pattern;
         char *prefix;
         char prefixed_path_to_extract[1024];
-        
+
         prefix = "squashfs-root/";
-        
+
         if(access(prefix, F_OK ) == -1 ) {
             if (mkdir_p(prefix) == -1) {
                 perror("mkdir_p error");
                 exit(EXIT_FAILURE);
             }
         }
-        
+
         if(argc == 3){
             pattern = argv[2];
-	    if (pattern[0] == '/') pattern++; // Remove leading '/'
-	}
-        
+            if (pattern[0] == '/') pattern++; // Remove leading '/'
+        }
+
         if ((err = sqfs_open_image(&fs, appimage_path, fs_offset)))
             exit(1);
-        
+
         if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))
             die("sqfs_traverse_open error");
         while (sqfs_traverse_next(&trv, &err)) {
@@ -354,7 +354,7 @@ main (int argc, char *argv[])
                     // fprintf(stderr, "inode.xtra.reg.file_size: %lu\n", inode.xtra.reg.file_size);
                     strcpy(prefixed_path_to_extract, "");
                     strcat(strcat(prefixed_path_to_extract, prefix), trv.path);
-		    fprintf(stderr, "%s\n", prefixed_path_to_extract);
+                    fprintf(stderr, "%s\n", prefixed_path_to_extract);
                     if(inode.base.inode_type == SQUASHFS_DIR_TYPE || inode.base.inode_type == SQUASHFS_LDIR_TYPE){
                         // fprintf(stderr, "inode.xtra.dir.parent_inode: %ui\n", inode.xtra.dir.parent_inode);
                         // fprintf(stderr, "mkdir_p: %s/\n", prefixed_path_to_extract);
@@ -411,12 +411,12 @@ main (int argc, char *argv[])
         sqfs_fd_close(fs.fd);
         exit(0);
     }
-    
+
     if(arg && strcmp(arg,"appimage-version")==0) {
         fprintf(stderr,"Version: %s\n", GIT_COMMIT);
         exit(0);
     }
-    
+
     if(arg && (strcmp(arg,"appimage-updateinformation")==0 || strcmp(arg,"appimage-updateinfo")==0)) {
         unsigned long offset = 0;
         unsigned long length = 0;
@@ -427,7 +427,7 @@ main (int argc, char *argv[])
         print_binary(appimage_path, offset, length);
         exit(0);
     }
-    
+
     if(arg && strcmp(arg,"appimage-signature")==0) {
         unsigned long offset = 0;
         unsigned long length = 0;
@@ -462,46 +462,46 @@ main (int argc, char *argv[])
     strncpy(mount_dir+12, basename(argv[0]), namelen);
     strncpy(mount_dir+12+namelen, "XXXXXX", 6);
     mount_dir[12+namelen+6] = 0; // null terminate destination
-    
+
     char filename[100]; /* enough for mount_dir + "/AppRun" */
     pid_t pid;
     char **real_argv;
     int i;
-    
+
     if (mkdtemp(mount_dir) == NULL) {
         exit (1);
     }
-    
+
     if (pipe (keepalive_pipe) == -1) {
         perror ("pipe error");
         exit (1);
     }
-    
+
     pid = fork ();
     if (pid == -1) {
         perror ("fork error");
         exit (1);
     }
-    
+
     if (pid == 0) {
         /* in child */
-        
+
         char *child_argv[5];
-        
+
         /* close read pipe */
         close (keepalive_pipe[0]);
-        
+
         char *dir = realpath(appimage_path, NULL );
-        
+
         char options[100];
         sprintf(options, "ro,offset=%lu", fs_offset);
-        
+
         child_argv[0] = dir;
         child_argv[1] = "-o";
         child_argv[2] = options;
         child_argv[3] = dir;
         child_argv[4] = mount_dir;
-        
+
         if(0 != fusefs_main (5, child_argv, fuse_mounted)){
             char *title;
             char *body;
@@ -510,41 +510,41 @@ main (int argc, char *argv[])
             "if you run it with the --appimage-extract option. \n"
             "See https://github.com/AppImage/AppImageKit/wiki/FUSE \n"
             "for more information";
-	    notify(title, body, 0); // 3 seconds timeout
+            notify(title, body, 0); // 3 seconds timeout
         };
     } else {
         /* in parent, child is $pid */
         int c;
-        
+
         /* close write pipe */
         close (keepalive_pipe[1]);
-        
+
         /* Pause until mounted */
         read (keepalive_pipe[0], &c, 1);
-        
-        
+
+
         dir_fd = open (mount_dir, O_RDONLY);
         if (dir_fd == -1) {
             perror ("open dir error");
             exit (1);
         }
-        
+
         res = dup2 (dir_fd, 1023);
         if (res == -1) {
             perror ("dup2 error");
             exit (1);
         }
         close (dir_fd);
-        
+
         strcpy (filename, mount_dir);
         strcat (filename, "/AppRun");
-        
+
         real_argv = malloc (sizeof (char *) * (argc + 1));
         for (i = 0; i < argc; i++) {
             real_argv[i] = argv[i];
         }
         real_argv[i] = NULL;
-        
+
         if(arg && strcmp(arg,"appimage-mount")==0) {
             printf("%s\n", mount_dir);
             for (;;) pause();
@@ -552,46 +552,46 @@ main (int argc, char *argv[])
 
         int length;
         char fullpath[PATH_MAX];
-        
+
         if(getenv("TARGET_APPIMAGE") == NULL){
             // If we are operating on this file itself
             length = readlink(appimage_path, fullpath, sizeof(fullpath));
-            fullpath[length] = '\0'; 
+            fullpath[length] = '\0';
         } else {
             // If we are operating on a different AppImage than this file
             sprintf(fullpath, "%s", appimage_path); // TODO: Make absolute
         }
-                
+
         /* Setting some environment variables that the app "inside" might use */
         setenv( "APPIMAGE", fullpath, 1 );
-	setenv( "ARGV0", argv0_path, 1 );
+        setenv( "ARGV0", argv0_path, 1 );
         setenv( "APPDIR", mount_dir, 1 );
 
         char portable_home_dir[PATH_MAX];
         char portable_config_dir[PATH_MAX];
-        
+
         /* If there is a directory with the same name as the AppImage plus ".home", then export $HOME */
         strcpy (portable_home_dir, fullpath);
-        strcat (portable_home_dir, ".home");        
+        strcat (portable_home_dir, ".home");
         if(is_writable_directory(portable_home_dir)){
             printf("Setting $HOME to %s\n", portable_home_dir);
-            setenv("HOME",portable_home_dir,1); 
+            setenv("HOME",portable_home_dir,1);
         }
 
         /* If there is a directory with the same name as the AppImage plus ".config", then export $XDG_CONFIG_HOME */
         strcpy (portable_config_dir, fullpath);
-        strcat (portable_config_dir, ".config");        
+        strcat (portable_config_dir, ".config");
         if(is_writable_directory(portable_config_dir)){
             printf("Setting $XDG_CONFIG_HOME to %s\n", portable_config_dir);
-            setenv("XDG_CONFIG_HOME",portable_config_dir,1); 
+            setenv("XDG_CONFIG_HOME",portable_config_dir,1);
         }
-        
+
         /* Original working directory */
         char cwd[1024];
         if (getcwd(cwd, sizeof(cwd)) != NULL) {
             setenv( "OWD", cwd, 1 );
         }
-        
+
         /* If we are operating on an AppImage different from this file,
          * then we do not execute the payload */
         if(getenv("TARGET_APPIMAGE") == NULL){
@@ -602,6 +602,6 @@ main (int argc, char *argv[])
             exit (1);
         }
     }
-    
+
     return 0;
 }


### PR DESCRIPTION
- Remove all trailing whitespace
- Remove all spaces and tabs on otherwise empty lines
- Convert tabs into spaces (file used mostly spaces before)