### PR TITLE
Embed signature keys

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ configure_file(
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/runtime
     COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/build-runtime.sh
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/build-runtime.sh
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/runtime.c
     DEPENDS squashfuse
 )

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -994,7 +994,7 @@ main (int argc, char *argv[])
                     size_t bytesRead = fread(buffer, sizeof(char), bufsize, ascfilefp);
                     totalBytesRead += bytesRead;
 
-                    if (totalBytesRead >= sig_length) {
+                    if (totalBytesRead > sig_length) {
                         die("Error: cannot embed key in AppImage: size exceeds reserved ELF section size");
                     }
 
@@ -1036,7 +1036,7 @@ main (int argc, char *argv[])
                     size_t bytesRead = fread(buffer, sizeof(char), bufsize, fp);
                     totalBytesRead += bytesRead;
 
-                    if (totalBytesRead >= key_length) {
+                    if (totalBytesRead > key_length) {
                         // read rest of process input to avoid broken pipe error
                         while (!feof(fp)) {
                             fread(buffer, sizeof(char), bufsize, fp);

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -918,9 +918,14 @@ main (int argc, char *argv[])
                 if (g_file_test(ascfile, G_FILE_TEST_IS_REGULAR))
                     unlink(ascfile);
 
-                char* key_arg = calloc(sizeof(char), strlen(sign_key) + strlen("--local-user ''"));
+                char* key_arg = NULL;
 
                 if (sign_key && strlen(sign_key) > 0) {
+                    key_arg = calloc(sizeof(char), strlen(sign_key) + strlen("--local-user ''"));
+
+                    if (key_arg == NULL)
+                        die("malloc() failed");
+
                     strcpy(key_arg, "--local-user '");
                     strcat(key_arg, sign_key);
                     strcat(key_arg, "'");
@@ -928,7 +933,7 @@ main (int argc, char *argv[])
 
                 sprintf(command,
                     "%s --detach-sign --armor %s %s %s",
-                    gpg2_path, key_arg, sign_args ? sign_args : "", digestfile
+                    gpg2_path, key_arg ? key_arg : "", sign_args ? sign_args : "", digestfile
                 );
 
                 free(key_arg);

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -1058,6 +1058,12 @@ main (int argc, char *argv[])
                 int exportexitcode = pclose(fp);
                 fp = NULL;
 
+                if (exportexitcode != 0) {
+                    char message[128];
+                    sprintf(message, "GPG key export failed: exit code %d", exportexitcode);
+                    die(message);
+                }
+
                 fclose(destinationfp);
             }
         }

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -1037,6 +1037,12 @@ main (int argc, char *argv[])
                     totalBytesRead += bytesRead;
 
                     if (totalBytesRead >= key_length) {
+                        // read rest of process input to avoid broken pipe error
+                        while (!feof(fp)) {
+                            fread(buffer, sizeof(char), bufsize, fp);
+                        }
+
+                        pclose(fp);
                         die("Error: cannot embed key in AppImage: size exceeds reserved ELF section size");
                     }
 

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -87,7 +87,7 @@ gchar *sqfs_comp = "gzip";
 gchar *exclude_file = NULL;
 gchar *runtime_file = NULL;
 gchar *sign_args = NULL;
-gchar *gpg_key = NULL;
+gchar *sign_key = NULL;
 gchar *pathToMksquashfs = NULL;
 
 // #####################################################################
@@ -439,6 +439,7 @@ static GOptionEntry entries[] =
     { "no-appstream", 'n', 0, G_OPTION_ARG_NONE, &no_appstream, "Do not check AppStream metadata", NULL },
     { "exclude-file", 0, 0, G_OPTION_ARG_STRING, &exclude_file, _exclude_file_desc, NULL },
     { "runtime-file", 0, 0, G_OPTION_ARG_STRING, &runtime_file, "Runtime file to use", NULL },
+    { "sign-key", 0, 0, G_OPTION_ARG_STRING, &sign_key, "Key ID to use for gpg[2] signatures", NULL},
     { "sign-args", 0, 0, G_OPTION_ARG_STRING, &sign_args, "Extra arguments to use when signing with gpg[2]", NULL},
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &remaining_args, NULL, NULL },
     { 0,0,0,0,0,0,0 }
@@ -917,7 +918,10 @@ main (int argc, char *argv[])
                 if (g_file_test(ascfile, G_FILE_TEST_IS_REGULAR))
                     unlink(ascfile);
 
-                sprintf(command, "%s --detach-sign --armor %s %s", gpg2_path, sign_args ? sign_args : "", digestfile);
+                sprintf(command,
+                    "%s --detach-sign --armor %s %s %s",
+                    gpg2_path, sign_key ? sign_key : "", sign_args ? sign_args : "", digestfile
+                );
 
                 if (verbose)
                     fprintf(stderr, "%s\n", command);

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -1002,7 +1002,7 @@ main (int argc, char *argv[])
 
                     if (bytesRead != bytesWritten) {
                         char message[128];
-                        sprintf(message, "Bytes read and written differ: %lu != %lu", bytesRead, bytesWritten);
+                        sprintf(message, "Bytes read and written differ: %lu != %lu", (long unsigned) bytesRead, (long unsigned) bytesWritten);
                         die(message);
                     }
                 }
@@ -1050,7 +1050,7 @@ main (int argc, char *argv[])
 
                     if (bytesRead != bytesWritten) {
                         char message[128];
-                        sprintf(message, "Error: Bytes read and written differ: %lu != %lu", bytesRead, bytesWritten);
+                        sprintf(message, "Error: Bytes read and written differ: %lu != %lu", (long unsigned) bytesRead, (long unsigned) bytesWritten);
                         die(message);
                     }
                 }

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -48,12 +48,17 @@ objcopy --add-section .upd_info=1024_blank_bytes \
 objcopy --add-section .sha256_sig=1024_blank_bytes \
         --set-section-flags .sha256_sig=noload,readonly runtime2.o runtime3.o
 
+cat 1024_blank_bytes 1024_blank_bytes 1024_blank_bytes 1024_blank_bytes > 4096_blank_bytes
+
+objcopy --add-section .sig_key=4096_blank_bytes \
+        --set-section-flags .sig_key=noload,readonly runtime3.o runtime4.o
+
 # Now statically link against libsquashfuse_ll, libsquashfuse and liblzma
 # and embed .upd_info and .sha256_sig sections
 # TODO: squashfuse_LIBRARIES is a semicolon separated list of values that has to be split during runtime of this script
 squashfuse_libs="@squashfuse_LIBRARIES@"
 $CC $small_FLAGS $small_LDFLAGS -o runtime "$repo_root"/elf.c "$repo_root"/notify.c "$repo_root"/getsection.c \
-    runtime3.o ${squashfuse_libs//;/ } \
+    runtime4.o ${squashfuse_libs//;/ } \
     -Wl,-Bdynamic -lpthread -l"@ZLIB_LIBRARIES@" -L"@ZLIB_LIBRARY_DIRS@" -Wl,-Bstatic "@xz_LIBRARIES@" -Wl,-Bdynamic -ldl
 $STRIP runtime
 


### PR DESCRIPTION
I am not sure whether a section size of 4 kiB is enough, but it seems to work with my local keys. We can further reduce the size by ~25% of the embedded key by removing `--armor`. Same goes for the actual signature.

Fixes #696.