### PR TITLE
Fix signature embedding on systems with multiple public keys in the keyring

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -932,7 +932,7 @@ main (int argc, char *argv[])
                 }
 
                 sprintf(command,
-                    "%s --detach-sign --armor %s %s %s",
+                    "%s --batch --detach-sign --armor %s %s %s",
                     gpg2_path, key_arg ? key_arg : "", sign_args ? sign_args : "", digestfile
                 );
 
@@ -1008,14 +1008,13 @@ main (int argc, char *argv[])
                 }
 
                 fclose(ascfilefp);
-
-                if (g_file_test(ascfile, G_FILE_TEST_IS_REGULAR))
-                    unlink(ascfile);
                 if (g_file_test(digestfile, G_FILE_TEST_IS_REGULAR))
                     unlink(digestfile);
+                if (g_file_test(ascfile, G_FILE_TEST_IS_REGULAR))
+                    unlink(ascfile);
 
                 // export key and write into section
-                sprintf(command, "%s --export --armor %s", gpg2_path, sign_key ? sign_key : "");
+                sprintf(command, "%s --batch --export --armor %s", gpg2_path, sign_key ? sign_key : "");
 
                 unsigned long key_offset, key_length;
                 rv = get_elf_section_offset_and_length(destination, ".sig_key", &key_offset, &key_length);

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -49,8 +49,9 @@ objcopy --add-section .sha256_sig=1024_blank_bytes \
         --set-section-flags .sha256_sig=noload,readonly runtime2.o runtime3.o
 
 cat 1024_blank_bytes 1024_blank_bytes 1024_blank_bytes 1024_blank_bytes > 4096_blank_bytes
+cat 4096_blank_bytes 4096_blank_bytes > 8192_blank_bytes
 
-objcopy --add-section .sig_key=4096_blank_bytes \
+objcopy --add-section .sig_key=8192_blank_bytes \
         --set-section-flags .sig_key=noload,readonly runtime3.o runtime4.o
 
 # Now statically link against libsquashfuse_ll, libsquashfuse and liblzma


### PR DESCRIPTION
This PR:

  - introduces `--batch` flag for any gpg[2] call to avoid any kind of interactive prompt
  - fixes @pamarcos's issues with embedding the signature when using `--sign` on systems with multiple public keys (where appimagetool exported all the public keys and tried to embed them, which quickly exceeded the ELF header section size)
  - increases the size of the `.sig_key` section to 8 kiB to support PGP keys with a size of 4096 bits