### PR TITLE
Revert "Temporarily use GitHub mirror for xz sources"

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -13,7 +13,7 @@ if(NOT USE_SYSTEM_XZ)
     message(STATUS "Downloading and building xz")
 
     ExternalProject_Add(xz
-        URL https://github.com/AppImage/external-resources/raw/master/sources/xz-5.2.3.tar.gz
+        URL https://tukaani.org/xz/xz-5.2.3.tar.gz
         URL_HASH SHA512=a5eb4f707cf31579d166a6f95dbac45cf7ea181036d1632b4f123a4072f502f8d57cd6e7d0588f0bf831a07b8fc4065d26589a25c399b95ddcf5f73435163da6
         CONFIGURE_COMMAND CFLAGS=-fPIC CPPFLAGS=-fPIC <SOURCE_DIR>/configure --disable-shared --enable-static --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/lib
         BUILD_COMMAND make


### PR DESCRIPTION
Reverts AppImage/AppImageKit#681

This is an attempt to revert to using the upstream mirror of the xz tarball. It appears that the upstream mirror works fine again.