### PR TITLE
Use quotes to pass arguments to zsyncmake

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -1117,7 +1117,7 @@ main (int argc, char *argv[])
             } else {
                 fprintf (stderr, "zsyncmake is available and updateinformation is provided, "
                 "hence generating zsync file\n");
-                sprintf (command, "%s %s -u %s", zsyncmake_path, destination, basename(destination));
+                sprintf (command, "'%s' '%s' -u '%s'", zsyncmake_path, destination, basename(destination));
                 if(verbose)
                     fprintf (stderr, "%s\n", command);
                 fp = popen(command, "r");


### PR DESCRIPTION
Otherwise file names with whitespaces are not passed correctly causing zsyncmake to hang.

---

Note: I haven't tested whether it actually works.