### PR TITLE
Disable .deb packaging by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,9 +103,13 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/sanitizers-cmake/cmake" ${CMA
 add_subdirectory(src)
 
 ################################
-#            packing           #
+#           packaging          #
 ################################
-include(cmake/cpack_debs.cmake)
+set(APPIMAGEKIT_PACKAGE_DEBS FALSE CACHE BOOL "")
+
+if(APPIMAGEKIT_PACKAGE_DEBS)
+    include(cmake/cpack_debs.cmake)
+endif()
 
 ################################
 # unit and functionality tests #

--- a/build.sh
+++ b/build.sh
@@ -69,7 +69,7 @@ git submodule update --init --recursive
 mkdir build
 cd build
 
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON -DAPPIMAGEKIT_PACKAGE_DEBS=ON
 make -j$JOBS
 make install DESTDIR=install_prefix/
 


### PR DESCRIPTION
For use as a submodule, the CPack packaging isn't needed, and might even conflict with the top level project's configuration. Therefore, by default, the packaging should be disabled, and explicitly enabled in our builds.