### PR TITLE
Make embedding of magic bytes configurable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 find_package(Sanitizers)
 
 # set up build script
+
+# if set to anything but ON, the magic bytes won't be embedded
+set(APPIMAGEKIT_EMBED_MAGIC_BYTES ON CACHE BOOL "")
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/build-runtime.sh.in
     ${CMAKE_CURRENT_BINARY_DIR}/build-runtime.sh

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -73,7 +73,9 @@ HEXLENGTH=$(objdump -h runtime | grep .upd_info | awk '{print $3}')
 dd bs=1 if=runtime skip=$(($(echo 0x$HEXOFFSET)+0)) count=$(($(echo 0x$HEXLENGTH)+0)) | xxd
 
 # Insert AppImage magic bytes
-printf '\x41\x49\x02' | dd of=runtime bs=1 seek=8 count=3 conv=notrunc
+if [ "@APPIMAGEKIT_EMBED_MAGIC_BYTES@" == "ON" ]; then
+    printf '\x41\x49\x02' | dd of=runtime bs=1 seek=8 count=3 conv=notrunc
+fi
 
 # Convert runtime into a data object that can be embedded into appimagetool
 ld -r -b binary -o data.o runtime


### PR DESCRIPTION
Required for AppImageLauncher to build a runtime without the magic bytes.