### PR TITLE
ccache support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,20 @@ include(ExternalProject)
 # enable testing globally
 include(CTest)
 
+# support for ccache
+# call CMake with -DUSE_CCACHE=ON to make use of it
+set(USE_CCACHE OFF CACHE BOOL "")
+if(USE_CCACHE)
+    find_program(CCACHE ccache)
+    if(CCACHE)
+        message(STATUS "Using ccache")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE})
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE})
+    else()
+        message(WARNING "USE_CCACHE set, but could not find ccache")
+    endif()
+endif()
+
 
 #####################
 # build information #


### PR DESCRIPTION
Use `-DUSE_CCACHE=ON` to use ccache for builds. Applies to dependency builds, too.