### PR TITLE
Make TARGET_APPIMAGE more useful

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,7 +142,7 @@ target_link_libraries(appimagetool
 )
 
 target_link_libraries(appimagetool
-    dl
+    ${CMAKE_DL_LIBS}
     pthread
     ${ZLIB_LIBRARIES}
     ${xz_LIBRARIES}
@@ -172,7 +172,7 @@ add_executable(appimaged appimaged.c notify.c elf.c getsection.c)
 
 target_link_libraries(appimaged
     pthread
-    dl
+    ${CMAKE_DL_LIBS}
     ${CAIRO_LIBRARIES}
     ${GLIB_LIBRARIES}
     ${GIO_LIBRARIES}

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -592,15 +592,11 @@ main (int argc, char *argv[])
             setenv( "OWD", cwd, 1 );
         }
 
-        /* If we are operating on an AppImage different from this file,
-         * then we do not execute the payload */
-        if(getenv("TARGET_APPIMAGE") == NULL){
-            /* TODO: Find a way to get the exit status and/or output of this */
-            execv (filename, real_argv);
-            /* Error if we continue here */
-            perror ("execv error");
-            exit (1);
-        }
+        /* TODO: Find a way to get the exit status and/or output of this */
+        execv (filename, real_argv);
+        /* Error if we continue here */
+        perror("execv error");
+        exit(1);
     }
 
     return 0;


### PR DESCRIPTION
With this PR, the runtime's `TARGET_APPIMAGE` environment variable can be used to actually run AppImages with an external runtime. Useful for AppImageLauncher.

Also contains a little patch for the CMake configuration.