### PR TITLE
Fix unit test fixtures

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,10 @@ add_custom_command(OUTPUT data.o
 add_custom_target(runtime DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/runtime)
 
 
+# include XDG basedir library
+add_subdirectory(xdg-basedir)
+
+
 # allow setting different path for mksquashfs after installation
 set(AUXILIARY_FILES_DESTINATION "lib/appimagekit" CACHE STRING "Target install directory for mksquashfs")
 
@@ -60,6 +64,7 @@ target_link_libraries(libappimage
     ${libarchive_LIBRARIES}
     ${inotify-tools_LIBRARIES}
     ${xz_LIBRARIES}
+    xdg-basedir
     PUBLIC
     pthread
     ${GLIB_LIBRARIES}
@@ -108,6 +113,7 @@ target_link_libraries(libappimage_static
     ${libarchive_LIBRARIES}
     ${inotify-tools_LIBRARIES}
     ${xz_LIBRARIES}
+    xdg-basedir
     PUBLIC
     pthread
     ${GLIB_LIBRARIES}
@@ -146,6 +152,7 @@ target_link_libraries(appimagetool
     pthread
     ${ZLIB_LIBRARIES}
     ${xz_LIBRARIES}
+    xdg-basedir
 )
 
 target_compile_definitions(appimagetool
@@ -181,6 +188,7 @@ target_link_libraries(appimaged
     ${xz_LIBRARIES}
     ${ZLIB_LIBRARIES}
     ${libarchive_LIBRARIES}
+    xdg-basedir
 )
 
 target_compile_definitions(appimaged
@@ -233,6 +241,7 @@ target_link_libraries(runtime-debug
     ${squashfuse_LIBRARIES}
     ${libarchive_LIBRARIES}
     ${xz_LIBRARIES}
+    xdg-basedir
     PUBLIC
     pthread
     ${GLIB_LIBRARIES}

--- a/src/appimaged.c
+++ b/src/appimaged.c
@@ -256,7 +256,9 @@ int main(int argc, char ** argv) {
     gchar *global_autostart_file = "/etc/xdg/autostart/appimaged.desktop";
     gchar *global_systemd_file = "/usr/lib/systemd/user/appimaged.service";
     gchar *partial_path = g_strdup_printf("autostart/appimagekit-appimaged.desktop");
-    gchar *destination = g_build_filename(g_get_user_config_dir(), partial_path, NULL);
+    char* config_home = xdg_config_home();
+    gchar *destination = g_build_filename(config_home, partial_path, NULL);
+    free(config_home);
 
     if(uninstall){
             if(g_file_test (installed_appimaged_location, G_FILE_TEST_EXISTS))

--- a/src/shared.c
+++ b/src/shared.c
@@ -192,7 +192,9 @@ void move_icon_to_destination(gchar *icon_path, gboolean verbose)
 #endif
         } else {
             g_free(dest_dir);
-            dest_dir = g_build_path("/", xdg_data_home(), "/icons/hicolor/", g_strdup_printf("%ix%i", w, h), "/apps/", NULL);
+            char* data_home = xdg_data_home();
+            dest_dir = g_build_path("/", data_home, "/icons/hicolor/", g_strdup_printf("%ix%i", w, h), "/apps/", NULL);
+            free(data_home);
         }
     }
     if(verbose)
@@ -370,7 +372,9 @@ gchar **squash_get_matching_files_install_icons_and_mime_data(sqfs* fs, char* pa
                 gchar *dest = NULL;
                 if(inode.base.inode_type == SQUASHFS_REG_TYPE) {
                     if(g_str_has_prefix(trv.path, "usr/share/icons/") || g_str_has_prefix(trv.path, "usr/share/pixmaps/") || (g_str_has_prefix(trv.path, "usr/share/mime/") && g_str_has_suffix(trv.path, ".xml"))){
-                        gchar *path = replace_str(trv.path, "usr/share", xdg_data_home());
+                        char* data_home = xdg_data_home();
+                        gchar *path = replace_str(trv.path, "usr/share", data_home);
+                        free(data_home);
                         char *dest_dirname = g_path_get_dirname(path);
                         g_free(path);
                         gchar *base_name = g_path_get_basename(trv.path);

--- a/src/xdg-basedir/CMakeLists.txt
+++ b/src/xdg-basedir/CMakeLists.txt
@@ -1,0 +1,14 @@
+# target_include_libraries was introduced in version 3.0
+cmake_minimum_required(VERSION 3.0)
+
+include_directories(${gtest_INCLUDE_DIRS})
+
+# force static linking
+add_library(xdg-basedir STATIC xdg-basedir.h xdg-basedir.c)
+target_include_directories(xdg-basedir PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(test-xdg-basedir test-xdg-basedir.cpp)
+target_link_libraries(test-xdg-basedir ${gtest_LIBRARIES} pthread xdg-basedir)
+if(NOT USE_SYSTEM_GTEST)
+    add_dependencies(test-xdg-basedir gtest)
+endif()

--- a/src/xdg-basedir/test-xdg-basedir.cpp
+++ b/src/xdg-basedir/test-xdg-basedir.cpp
@@ -1,0 +1,166 @@
+// system headers
+#include <climits>
+#include <string>
+
+// library headers
+#include <gtest/gtest.h>
+
+// local headers
+#include "xdg-basedir.h"
+
+bool compareStrings(const char* str1, const char* str2) {
+    if (str1 == NULL || str2 == NULL)
+        return false;
+
+    return strcmp(str1, str2) == 0;
+}
+
+TEST(xdg_basedir_test, test_user_home_default_value) {
+    char* home = user_home();
+    EXPECT_PRED2(compareStrings, home, getenv("HOME"));
+    free(home);
+}
+
+TEST(xdg_basedir_test, test_user_home_custom_value) {
+    char* oldValue = strdup(getenv("HOME"));
+    setenv("HOME", "ABCDEFG", true);
+
+    char* currentValue = user_home();
+    EXPECT_PRED2(compareStrings, currentValue, getenv("HOME"));
+    EXPECT_PRED2(compareStrings, currentValue, "ABCDEFG");
+    free(currentValue);
+
+    setenv("HOME", oldValue, true);
+    free(oldValue);
+}
+
+TEST(xdg_basedir_test, test_xdg_data_home_default_value) {
+    // make sure env var is not set, to force function to use default value
+    char* oldValue;
+
+    if ((oldValue = getenv("XDG_DATA_HOME")) != NULL) {
+        unsetenv("XDG_DATA_HOME");
+    }
+
+    char* currentValue = xdg_data_home();
+
+    // too lazy to calculate size
+    char* expectedValue = static_cast<char*>(malloc(PATH_MAX));
+    strcpy(expectedValue, getenv("HOME"));
+    strcat(expectedValue, "/.local/share");
+
+    EXPECT_PRED2(compareStrings, currentValue, expectedValue);
+
+    free(expectedValue);
+    free(currentValue);
+
+    if (oldValue != NULL) {
+        setenv("XDG_DATA_HOME", oldValue, true);
+        free(oldValue);
+    }
+}
+
+TEST(xdg_basedir_test, test_xdg_data_home_custom_value) {
+    char* oldValue = getenv("XDG_DATA_HOME");
+    setenv("XDG_DATA_HOME", "HIJKLM", true);
+
+    char* currentValue = xdg_data_home();
+    EXPECT_PRED2(compareStrings, currentValue, "HIJKLM");
+    free(currentValue);
+
+    if (oldValue != NULL) {
+        setenv("XDG_DATA_HOME", oldValue, true);
+        free(oldValue);
+    } else {
+        unsetenv("XDG_DATA_HOME");
+    }
+}
+
+TEST(xdg_basedir_test, test_xdg_config_home_default_value) {
+    // make sure env var is not set, to force function to use default value
+    char* oldValue;
+
+    if ((oldValue = getenv("XDG_CONFIG_HOME")) != NULL) {
+        unsetenv("XDG_CONFIG_HOME");
+    }
+
+    char* currentValue = xdg_config_home();
+
+    // too lazy to calculate size
+    char* expectedValue = static_cast<char*>(malloc(PATH_MAX));
+    strcpy(expectedValue, getenv("HOME"));
+    strcat(expectedValue, "/.config");
+
+    EXPECT_PRED2(compareStrings, currentValue, expectedValue);
+
+    free(expectedValue);
+    free(currentValue);
+
+    if (oldValue != NULL) {
+        setenv("XDG_CONFIG_HOME", oldValue, true);
+        free(oldValue);
+    }
+}
+
+TEST(xdg_basedir_test, test_xdg_config_home_custom_value) {
+    char* oldValue = getenv("XDG_CONFIG_HOME");
+    setenv("XDG_CONFIG_HOME", "NOPQRS", true);
+
+    char* currentValue = xdg_config_home();
+    EXPECT_PRED2(compareStrings, currentValue, "NOPQRS");
+    free(currentValue);
+
+    if (oldValue != NULL) {
+        setenv("XDG_CONFIG_HOME", oldValue, true);
+        free(oldValue);
+    } else {
+        unsetenv("XDG_CONFIG_HOME");
+    }
+}
+
+TEST(xdg_basedir_test, test_xdg_cache_home_default_value) {
+    // make sure env var is not set, to force function to use default value
+    char* oldValue;
+
+    if ((oldValue = getenv("XDG_CACHE_HOME")) != NULL) {
+        unsetenv("XDG_CACHE_HOME");
+    }
+
+    char* currentValue = xdg_cache_home();
+
+    // too lazy to calculate size
+    char* expectedValue = static_cast<char*>(malloc(PATH_MAX));
+    strcpy(expectedValue, getenv("HOME"));
+    strcat(expectedValue, "/.cache");
+
+    EXPECT_PRED2(compareStrings, currentValue, expectedValue);
+
+    free(expectedValue);
+    free(currentValue);
+
+    if (oldValue != NULL) {
+        setenv("XDG_CACHE_HOME", oldValue, true);
+        free(oldValue);
+    }
+}
+
+TEST(xdg_basedir_test, test_xdg_cache_home_custom_value) {
+    char* oldValue = getenv("XDG_CACHE_HOME");
+    setenv("XDG_CACHE_HOME", "TUVWXY", true);
+
+    char* currentValue = xdg_cache_home();
+    EXPECT_PRED2(compareStrings, currentValue, "TUVWXY");
+    free(currentValue);
+
+    if (oldValue != NULL) {
+        setenv("XDG_CACHE_HOME", oldValue, true);
+        free(oldValue);
+    } else {
+        unsetenv("XDG_CACHE_HOME");
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/xdg-basedir/xdg-basedir.c
+++ b/src/xdg-basedir/xdg-basedir.c
@@ -1,0 +1,67 @@
+#include "xdg-basedir.h"
+#include <string.h>
+#include <stdlib.h>
+
+char* user_home() {
+    return strdup(getenv("HOME"));
+}
+
+char* xdg_config_home()  {
+    char* config_home;
+
+    if ((config_home = getenv("XDG_CONFIG_HOME")) == NULL) {
+        char* home = user_home();
+        static const char const* suffix = "/.config";
+
+        config_home = calloc(strlen(home) + strlen(suffix) + 1, sizeof(char));
+
+        strcpy(config_home, home);
+        strcat(config_home, suffix);
+
+        free(home);
+
+        return config_home;
+    } else {
+        return strdup(config_home);
+    }
+}
+
+char* xdg_data_home() {
+    char* data_home;
+
+    if ((data_home = getenv("XDG_DATA_HOME")) == NULL) {
+        char* home = user_home();
+        static const char const* suffix = "/.local/share";
+
+        data_home = calloc(strlen(home) + strlen(suffix) + 1, sizeof(char));
+
+        strcpy(data_home, home);
+        strcat(data_home, suffix);
+
+        free(home);
+
+        return data_home;
+    } else {
+        return strdup(data_home);
+    }
+}
+
+char* xdg_cache_home() {
+    char* cache_home;
+
+    if ((cache_home = getenv("XDG_CACHE_HOME")) == NULL) {
+        char* home = user_home();
+        static const char const* suffix = "/.cache";
+
+        cache_home = calloc(strlen(home) + strlen(suffix) + 1, sizeof(char));
+
+        strcpy(cache_home, home);
+        strcat(cache_home, suffix);
+
+        free(home);
+
+        return cache_home;
+    } else {
+        return strdup(cache_home);
+    }
+}

--- a/src/xdg-basedir/xdg-basedir.c
+++ b/src/xdg-basedir/xdg-basedir.c
@@ -7,9 +7,9 @@ char* user_home() {
 }
 
 char* xdg_config_home()  {
-    char* config_home;
+    char* config_home = getenv("XDG_CONFIG_HOME");
 
-    if ((config_home = getenv("XDG_CONFIG_HOME")) == NULL) {
+    if (config_home == NULL) {
         char* home = user_home();
         static const char const* suffix = "/.config";
 
@@ -27,9 +27,9 @@ char* xdg_config_home()  {
 }
 
 char* xdg_data_home() {
-    char* data_home;
+    char* data_home = getenv("XDG_DATA_HOME");
 
-    if ((data_home = getenv("XDG_DATA_HOME")) == NULL) {
+    if (data_home == NULL) {
         char* home = user_home();
         static const char const* suffix = "/.local/share";
 
@@ -47,9 +47,9 @@ char* xdg_data_home() {
 }
 
 char* xdg_cache_home() {
-    char* cache_home;
+    char* cache_home = getenv("XDG_CACHE_HOME");
 
-    if ((cache_home = getenv("XDG_CACHE_HOME")) == NULL) {
+    if (cache_home == NULL) {
         char* home = user_home();
         static const char const* suffix = "/.cache";
 

--- a/src/xdg-basedir/xdg-basedir.h
+++ b/src/xdg-basedir/xdg-basedir.h
@@ -1,0 +1,33 @@
+#ifndef XDG_BASEDIR_H
+#define XDG_BASEDIR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Convenience wrapper. Result must be free'd.
+ */
+char* user_home();
+
+/*
+ *
+ */
+char* xdg_config_home();
+
+/*
+ *
+ */
+char* xdg_data_home();
+
+/*
+ *
+ */
+char* xdg_cache_home();
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* XDG_BASEDIR_H */

--- a/src/xdg-basedir/xdg-basedir.h
+++ b/src/xdg-basedir/xdg-basedir.h
@@ -6,22 +6,29 @@ extern "C" {
 #endif
 
 /*
- * Convenience wrapper. Result must be free'd.
+ * Get user's home directory. Convenience wrapper for getenv("HOME").
+ * Returns a freshly allocated char array that must be free'd after usage.
  */
 char* user_home();
 
 /*
- *
+ * Get XDG config home directory using $XDG_CONFIG_HOME environment variable.
+ * Falls back to default value ~/.config if environment variable is not set.
+ * Returns a freshly allocated char array that must be free'd after usage.
  */
 char* xdg_config_home();
 
 /*
- *
+ * Get XDG data home directory using $XDG_DATA_HOME environment variable.
+ * Falls back to default value ~/.local/share if environment variable is not set.
+ * Returns a freshly allocated char array that must be free'd after usage.
  */
 char* xdg_data_home();
 
 /*
- *
+ * Get XDG cache home directory using $XDG_CACHE_HOME environment variable.
+ * Falls back to default value ~/.cache if environment variable is not set.
+ * Returns a freshly allocated char array that must be free'd after usage.
  */
 char* xdg_cache_home();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_libappimage
         pthread
         libappimage
+        xdg-basedir
         ${gtest_LIBRARIES}
     )
 
@@ -41,6 +42,7 @@ if(BUILD_TESTING)
         ${libarchive_LIBRARIES}
         ${inotify-tools_LIBRARIES}
         ${xz_LIBRARIES}
+        xdg-basedir
         pthread
         ${GLIB_LIBRARIES}
         ${GIO_LIBRARIES}
@@ -85,6 +87,7 @@ if(BUILD_TESTING)
         ${libarchive_LIBRARIES}
         ${inotify-tools_LIBRARIES}
         ${xz_LIBRARIES}
+        xdg-basedir
         pthread
         ${GLIB_LIBRARIES}
         ${GIO_LIBRARIES}

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -25,23 +25,23 @@ public:
 
         tempHome = tempDir + "/HOME";
 
+        mkdir(tempHome.c_str(), 0700);
+
         oldHome = getenv("HOME");
         oldXdgDataHome = getenv("XDG_DATA_HOME");
         oldXdgConfigHome = getenv("XDG_CONFIG_HOME");
 
-        std::stringstream newHome;
-        newHome << "HOME=" << tempHome;
-        putenv(strdup(newHome.str().c_str()));
+        std::string newXdgDataHome = tempHome + "/.local/share";
+        std::string newXdgConfigHome = tempHome + "/.config";
 
-        std::stringstream newXdgDataHome;
-        newXdgDataHome << "XDG_DATA_HOME=" << tempHome << "/.local/share";
-        putenv(strdup(newXdgDataHome.str().c_str()));
+        setenv("HOME", tempHome.c_str(), true);
+        setenv("XDG_DATA_HOME", newXdgDataHome.c_str(), true);
+        setenv("XDG_CONFIG_HOME", newXdgConfigHome.c_str(), true);
 
-        std::stringstream newXdgConfigHome;
-        newXdgDataHome << "XDG_CONFIG_HOME=" << tempHome << "/.config";
-        putenv(strdup(newXdgConfigHome.str().c_str()));
-
-        mkdir(tempHome.c_str(), 0700);
+        EXPECT_EQ(getenv("HOME"), tempHome);
+        EXPECT_EQ(tempHome, g_get_home_dir());
+        EXPECT_EQ(newXdgDataHome, g_get_user_data_dir());
+        EXPECT_EQ(newXdgConfigHome, g_get_user_config_dir());
     };
 
     ~AppImageKitTest() {
@@ -50,25 +50,19 @@ public:
         }
 
         if (oldHome != NULL) {
-            std::stringstream newHome;
-            newHome << "HOME=" << oldHome;
-            putenv(strdup(newHome.str().c_str()));
+            setenv("HOME", oldHome, true);
         } else {
-            unsetenv("XDG_DATA_HOME");
+            unsetenv("HOME");
         }
 
         if (oldXdgDataHome != NULL) {
-            std::stringstream newXdgDataHome;
-            newXdgDataHome << "XDG_DATA_HOME=" << oldXdgDataHome;
-            putenv(strdup(newXdgDataHome.str().c_str()));
+            setenv("XDG_DATA_HOME", oldXdgDataHome, true);
         } else {
             unsetenv("XDG_DATA_HOME");
         }
 
         if (oldXdgConfigHome != NULL) {
-            std::stringstream newXdgConfigHome;
-            newXdgConfigHome << "XDG_CONFIG_HOME=" << oldXdgConfigHome;
-            putenv(strdup(newXdgConfigHome.str().c_str()));
+            setenv("XDG_CONFIG_HOME", oldXdgConfigHome, true);
         } else {
             unsetenv("XDG_CONFIG_HOME");
         }

--- a/tests/fixtures.h
+++ b/tests/fixtures.h
@@ -38,6 +38,11 @@ public:
         setenv("XDG_DATA_HOME", newXdgDataHome.c_str(), true);
         setenv("XDG_CONFIG_HOME", newXdgConfigHome.c_str(), true);
 
+        // reset GLib internal caches
+        // "might" leak memory, according to docs, hence nothing we could fix
+        // https://developer.gnome.org/glib/stable/glib-Miscellaneous-Utility-Functions.html#g-reload-user-special-dirs-cache
+        g_reload_user_special_dirs_cache();
+
         EXPECT_EQ(getenv("HOME"), tempHome);
         EXPECT_EQ(tempHome, g_get_home_dir());
         EXPECT_EQ(newXdgDataHome, g_get_user_data_dir());

--- a/tests/test_libappimage.cpp
+++ b/tests/test_libappimage.cpp
@@ -35,20 +35,24 @@ namespace AppImageTests {
             gchar *sum = appimage_get_md5(path.c_str());
 
             GDir *dir;
-            GError *error;
-            const gchar *filename;
+            GError *error = NULL;
+            const gchar *filename = NULL;
 
-            char *apps_path = g_strconcat(g_get_user_data_dir(), "/applications/", NULL);
+            char *data_home = xdg_data_home();
+            char *apps_path = g_strconcat(data_home, "/applications/", NULL);
+            free(data_home);
 
             bool found = false;
             dir = g_dir_open(apps_path, 0, &error);
-            while ((filename = g_dir_read_name(dir))) {
-                gchar *m = g_strrstr(filename, sum);
+            if (dir != NULL) {
+                while ((filename = g_dir_read_name(dir))) {
+                    gchar* m = g_strrstr(filename, sum);
 
-                if (m != NULL)
-                    found = true;
+                    if (m != NULL)
+                        found = true;
+                }
+                g_dir_close(dir);
             }
-            g_dir_close(dir);
             g_free(apps_path);
             g_free(sum);
             return found;
@@ -127,10 +131,13 @@ namespace AppImageTests {
         appimage_create_thumbnail(appImage_type_1_file_path.c_str());
 
         gchar *sum = appimage_get_md5(appImage_type_1_file_path.c_str());
-        std::string path = std::string(g_get_user_cache_dir())
+
+        char *cache_home = xdg_cache_home();
+        std::string path = std::string(cache_home)
                            + "/thumbnails/normal/"
                            + std::string(sum) + ".png";
 
+        g_free(cache_home);
         g_free(sum);
 
         ASSERT_TRUE(g_file_test(path.c_str(), G_FILE_TEST_EXISTS));
@@ -143,10 +150,13 @@ namespace AppImageTests {
         appimage_create_thumbnail(appImage_type_2_file_path.c_str());
 
         gchar *sum = appimage_get_md5(appImage_type_2_file_path.c_str());
-        std::string path = std::string(g_get_user_cache_dir())
+
+        char* cache_home = xdg_cache_home();
+        std::string path = std::string(cache_home)
                            + "/thumbnails/normal/"
                            + std::string(sum) + ".png";
 
+        g_free(cache_home);
         g_free(sum);
 
         ASSERT_TRUE(g_file_test(path.c_str(), G_FILE_TEST_EXISTS));


### PR DESCRIPTION
The unit test fixtures I wrote a while ago are supposed to ensure that files that are created by library calls in the unit tests are cleaned up from the host system properly. Before, the changes were performed in the users' home directories, which is really not a good idea. Therefore, I wanted to put it all into a unit-test specific directory.

As I found out recently, this doesn't work as expected, though. The files are now created in a temporary directory in `/tmp`, so far so good. The fixture tries to remove this directory and create a new one for every test, though. Due to some internal caching in GLib, however, the values are initiated only once from the environment variables, therefore the files will all be put in a single directory. This directory will persist after the unit tests have finished (as it should've been cleaned up after the first unit test), which is a problem. When running the unit tests a lot of times, `/tmp` will fill with those leftover directories.

This PR is an attempt to fix GLib's weird behavior.