### PR TITLE
Get desktop file path when registering an AppImage

### DIFF
--- a/include/appimage/appimage.h
+++ b/include/appimage/appimage.h
@@ -12,19 +12,38 @@ char *appimage_get_md5(char const* path);
 /* Check if a file is an AppImage. Returns the image type if it is, or -1 if it isn't */
 int appimage_get_type(const char* path, bool verbose);
 
+/*
+ * Checks whether an AppImage is registered in system by checking whether the files have been copied to the right locations
+ */
 bool appimage_is_registered_in_system(const char* path);
 
 /* Register a type 1 AppImage in the system */
 bool appimage_type1_register_in_system(const char *path, bool verbose);
+/*
+ * Register a type 1 AppImage in the system
+ * desktop_file_path will be set to the path of the integrated desktop file, unless it is NULL.
+ */
+bool appimage_type1_register_in_system_get_desktop_file_path(const char *path, bool verbose, char **desktop_file_path);
 
 /* Register a type 2 AppImage in the system */
 bool appimage_type2_register_in_system(const char *path, bool verbose);
+/*
+ * Register a type 2 AppImage in the system
+ * desktop_file_path will be set to the path of the integrated desktop file, unless it is NULL.
+ */
+bool appimage_type2_register_in_system_get_desktop_file_path(const char *path, bool verbose, char **desktop_file_path);
 
 /*
  * Register an AppImage in the system
  * Returns 0 on success, non-0 otherwise.
  */
 int appimage_register_in_system(const char *path, bool verbose);
+/*
+ * Register an AppImage in the system
+ * Set app_for_removal to add a [Desktop Action] for removing the AppImage using that executable.
+ * desktop_file_path will be set to the path of the integrated desktop file, unless it is NULL.
+ */
+int appimage_register_in_system_get_desktop_file_path(const char *path, bool verbose, char **desktop_file_path);
 
 /* Unregister an AppImage in the system */
 int appimage_unregister_in_system(const char *path, bool verbose);

--- a/src/appimaged.c
+++ b/src/appimaged.c
@@ -249,7 +249,10 @@ int main(int argc, char ** argv) {
         exit(1);
     }
 
-    gchar *user_bin_dir = g_build_filename(g_get_home_dir(), "/.local/bin", NULL);
+    char* home_dir = user_home();
+    gchar *user_bin_dir = g_build_filename(home_dir, "/.local/bin", NULL);
+    free(home_dir);
+
     gchar *installed_appimaged_location = g_build_filename(user_bin_dir, "appimaged", NULL);
     const gchar *appimage_location = g_getenv("APPIMAGE");
     gchar *own_desktop_file_location = g_build_filename(g_getenv("APPDIR"), "/appimaged.desktop", NULL);
@@ -320,11 +323,16 @@ int main(int argc, char ** argv) {
         }
     }
 
+
     add_dir_to_watch(user_bin_dir);
     add_dir_to_watch(g_get_user_special_dir(G_USER_DIRECTORY_DOWNLOAD));
-    add_dir_to_watch(g_build_filename(g_get_home_dir(), "/bin", NULL));
-    add_dir_to_watch(g_build_filename(g_get_home_dir(), "/.bin", NULL));
-    add_dir_to_watch(g_build_filename(g_get_home_dir(), "/Applications", NULL));
+
+    char* home_dir = user_home();
+    add_dir_to_watch(g_build_filename(home_dir, "/bin", NULL));
+    add_dir_to_watch(g_build_filename(home_dir, "/.bin", NULL));
+    add_dir_to_watch(g_build_filename(home_dir, "/Applications", NULL));
+    free(home_dir);
+
     add_dir_to_watch(g_build_filename("/Applications", NULL));
     // Perhaps we should determine the following dynamically using something like
     // mount | grep -i iso | head -n 1 | cut -d ' ' -f 3

--- a/src/appimaged.c
+++ b/src/appimaged.c
@@ -249,9 +249,12 @@ int main(int argc, char ** argv) {
         exit(1);
     }
 
-    char* home_dir = user_home();
-    gchar *user_bin_dir = g_build_filename(home_dir, "/.local/bin", NULL);
-    free(home_dir);
+    gchar *user_bin_dir;
+    {
+        char* home_dir = user_home();
+        user_bin_dir = g_build_filename(home_dir, "/.local/bin", NULL);
+        free(home_dir);
+    }
 
     gchar *installed_appimaged_location = g_build_filename(user_bin_dir, "appimaged", NULL);
     const gchar *appimage_location = g_getenv("APPIMAGE");
@@ -327,11 +330,13 @@ int main(int argc, char ** argv) {
     add_dir_to_watch(user_bin_dir);
     add_dir_to_watch(g_get_user_special_dir(G_USER_DIRECTORY_DOWNLOAD));
 
-    char* home_dir = user_home();
-    add_dir_to_watch(g_build_filename(home_dir, "/bin", NULL));
-    add_dir_to_watch(g_build_filename(home_dir, "/.bin", NULL));
-    add_dir_to_watch(g_build_filename(home_dir, "/Applications", NULL));
-    free(home_dir);
+    {
+        char* home_dir = user_home();
+        add_dir_to_watch(g_build_filename(home_dir, "/bin", NULL));
+        add_dir_to_watch(g_build_filename(home_dir, "/.bin", NULL));
+        add_dir_to_watch(g_build_filename(home_dir, "/Applications", NULL));
+        free(home_dir);
+    }
 
     add_dir_to_watch(g_build_filename("/Applications", NULL));
     // Perhaps we should determine the following dynamically using something like

--- a/src/shared.h
+++ b/src/shared.h
@@ -88,12 +88,15 @@ int appimage_register_in_system(char* path, gboolean verbose);
 
 void appimage_create_thumbnail(const gchar* appimage_file_path, gboolean verbose);
 
-bool appimage_type2_register_in_system(char* path, gboolean verbose);
+bool appimage_type2_register_in_system_get_desktop_file_path(const char* path, gboolean verbose, char** desktop_file_path);
+
+bool appimage_type2_register_in_system(const char* path, gboolean verbose);
+
+bool appimage_type1_register_in_system_get_desktop_file_path(const char* path, gboolean verbose, char** desktop_file_path);
 
 bool appimage_type1_register_in_system(const char* path, gboolean verbose);
 
-bool write_edited_desktop_file(GKeyFile* key_file_structure, const char* appimage_path, gchar* desktop_filename,
-                               int appimage_type, char* md5, gboolean verbose);
+bool write_edited_desktop_file(GKeyFile* key_file_structure, const char* appimage_path, gchar* desktop_filename, int appimage_type, char* md5, gboolean verbose, char** desktop_file_path);
 
 gboolean g_key_file_load_from_squash(sqfs* fs, char* path, GKeyFile* key_file_structure, gboolean verbose);
 

--- a/tests/test_shared.cpp
+++ b/tests/test_shared.cpp
@@ -38,7 +38,7 @@ TEST_F(SharedCTest, test_write_desktop_file_exec) {
     gboolean success = g_key_file_load_from_data(keyFile, buffer.data(), buffer.size(), G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS, NULL);
 
     if (success) {
-        write_edited_desktop_file(keyFile, "testpath", strdup("abc"), 1, strdup("def"), false);
+        write_edited_desktop_file(keyFile, "testpath", strdup("abc"), 1, strdup("def"), false, NULL);
     }
 
     g_key_file_free(keyFile);


### PR DESCRIPTION
Since it is a rather expensive task to get the path of a desktop file for an AppImage after it has been integrated (as the AppImage needs to be opened and searched for the root desktop file, since its filename is a component of said path), this PR changes the registration functions to "return" this path as well.

The API has been extended by replacing the original functions with wrappers for the new ones, making these changes 100% backwards compatible.