### PR TITLE
Revert "Get desktop file path when registering an AppImage"

### DIFF
--- a/include/appimage/appimage.h
+++ b/include/appimage/appimage.h
@@ -12,38 +12,19 @@ char *appimage_get_md5(char const* path);
 /* Check if a file is an AppImage. Returns the image type if it is, or -1 if it isn't */
 int appimage_get_type(const char* path, bool verbose);
 
-/*
- * Checks whether an AppImage is registered in system by checking whether the files have been copied to the right locations
- */
 bool appimage_is_registered_in_system(const char* path);
 
 /* Register a type 1 AppImage in the system */
 bool appimage_type1_register_in_system(const char *path, bool verbose);
-/*
- * Register a type 1 AppImage in the system
- * desktop_file_path will be set to the path of the integrated desktop file, unless it is NULL.
- */
-bool appimage_type1_register_in_system_get_desktop_file_path(const char *path, bool verbose, char **desktop_file_path);
 
 /* Register a type 2 AppImage in the system */
 bool appimage_type2_register_in_system(const char *path, bool verbose);
-/*
- * Register a type 2 AppImage in the system
- * desktop_file_path will be set to the path of the integrated desktop file, unless it is NULL.
- */
-bool appimage_type2_register_in_system_get_desktop_file_path(const char *path, bool verbose, char **desktop_file_path);
 
 /*
  * Register an AppImage in the system
  * Returns 0 on success, non-0 otherwise.
  */
 int appimage_register_in_system(const char *path, bool verbose);
-/*
- * Register an AppImage in the system
- * Set app_for_removal to add a [Desktop Action] for removing the AppImage using that executable.
- * desktop_file_path will be set to the path of the integrated desktop file, unless it is NULL.
- */
-int appimage_register_in_system_get_desktop_file_path(const char *path, bool verbose, char **desktop_file_path);
 
 /* Unregister an AppImage in the system */
 int appimage_unregister_in_system(const char *path, bool verbose);

--- a/src/appimaged.c
+++ b/src/appimaged.c
@@ -249,13 +249,7 @@ int main(int argc, char ** argv) {
         exit(1);
     }
 
-    gchar *user_bin_dir;
-    {
-        char* home_dir = user_home();
-        user_bin_dir = g_build_filename(home_dir, "/.local/bin", NULL);
-        free(home_dir);
-    }
-
+    gchar *user_bin_dir = g_build_filename(g_get_home_dir(), "/.local/bin", NULL);
     gchar *installed_appimaged_location = g_build_filename(user_bin_dir, "appimaged", NULL);
     const gchar *appimage_location = g_getenv("APPIMAGE");
     gchar *own_desktop_file_location = g_build_filename(g_getenv("APPDIR"), "/appimaged.desktop", NULL);
@@ -326,18 +320,11 @@ int main(int argc, char ** argv) {
         }
     }
 
-
     add_dir_to_watch(user_bin_dir);
     add_dir_to_watch(g_get_user_special_dir(G_USER_DIRECTORY_DOWNLOAD));
-
-    {
-        char* home_dir = user_home();
-        add_dir_to_watch(g_build_filename(home_dir, "/bin", NULL));
-        add_dir_to_watch(g_build_filename(home_dir, "/.bin", NULL));
-        add_dir_to_watch(g_build_filename(home_dir, "/Applications", NULL));
-        free(home_dir);
-    }
-
+    add_dir_to_watch(g_build_filename(g_get_home_dir(), "/bin", NULL));
+    add_dir_to_watch(g_build_filename(g_get_home_dir(), "/.bin", NULL));
+    add_dir_to_watch(g_build_filename(g_get_home_dir(), "/Applications", NULL));
     add_dir_to_watch(g_build_filename("/Applications", NULL));
     // Perhaps we should determine the following dynamically using something like
     // mount | grep -i iso | head -n 1 | cut -d ' ' -f 3

--- a/src/shared.c
+++ b/src/shared.c
@@ -507,7 +507,7 @@ gchar *build_installed_desktop_file_path(gchar* md5, gchar* desktop_filename) {
 }
 
 /* Write a modified desktop file to disk that points to the AppImage */
-bool write_edited_desktop_file(GKeyFile *key_file_structure, const char* appimage_path, gchar* desktop_filename, int appimage_type, char *md5, gboolean verbose, char **desktop_file_path) {
+bool write_edited_desktop_file(GKeyFile *key_file_structure, const char* appimage_path, gchar* desktop_filename, int appimage_type, char *md5, gboolean verbose){
     if(!g_key_file_has_key(key_file_structure, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_EXEC, NULL)){
 #ifdef STANDALONE
         fprintf(stderr, "Desktop file has no Exec key\n");
@@ -783,11 +783,6 @@ bool write_edited_desktop_file(GKeyFile *key_file_structure, const char* appimag
     /* GNOME shows the icon and name on the desktop file only if it is executable */
     chmod(destination, 0755);
 
-    // set desktop_file_path if possible
-    if (desktop_file_path != NULL) {
-        *desktop_file_path = strdup(destination);
-    }
-
     g_free(destination);
 
     return true;
@@ -1039,7 +1034,7 @@ bool archive_copy_icons_recursively_to_destination(struct archive** a, const gch
 }
 
 /* Register a type 1 AppImage in the system */
-bool appimage_type1_register_in_system_get_desktop_file_path(const char *path, gboolean verbose, char **desktop_file_path)
+bool appimage_type1_register_in_system(const char *path, gboolean verbose)
 {
 #ifdef STANDALONE
     fprintf(stderr, "ISO9660 based type 1 AppImage\n");
@@ -1088,7 +1083,7 @@ bool appimage_type1_register_in_system_get_desktop_file_path(const char *path, g
         if (verbose)
             fprintf(stderr, "desktop_icon_value_original: %s\n", desktop_icon_value_original);
 
-        if (!write_edited_desktop_file(key_file, path, desktop_filename, 1, md5, verbose, desktop_file_path)) {
+        if (!write_edited_desktop_file(key_file, path, desktop_filename, 1, md5, verbose)) {
 #ifdef STANDALONE
             fprintf(stderr, "Failed to install desktop file\n");
 #endif
@@ -1129,10 +1124,6 @@ bool appimage_type1_register_in_system_get_desktop_file_path(const char *path, g
     return !errored;
 }
 
-bool appimage_type1_register_in_system(const char* path, gboolean verbose) {
-    return appimage_type1_register_in_system_get_desktop_file_path(path, verbose, NULL);
-}
-
 bool appimage_type2_get_desktop_filename_and_key_file(sqfs* fs, gchar** desktop_filename, gchar* md5, GKeyFile** key_file, gboolean verbose) {
     /* TOOO: Change so that only one run of squash_get_matching_files is needed in total,
      * this should hopefully improve performance */
@@ -1163,7 +1154,7 @@ bool appimage_type2_get_desktop_filename_and_key_file(sqfs* fs, gchar** desktop_
 }
 
 /* Register a type 2 AppImage in the system */
-bool appimage_type2_register_in_system_get_desktop_file_path(const char* path, gboolean verbose, char** desktop_file_path) {
+bool appimage_type2_register_in_system(char *path, gboolean verbose) {
 #ifdef STANDALONE
     fprintf(stderr, "squashfs based type 2 AppImage\n");
 #endif
@@ -1212,7 +1203,7 @@ bool appimage_type2_register_in_system_get_desktop_file_path(const char* path, g
         } else {
             if (verbose)
                 fprintf(stderr, "desktop_icon_value_original: %s\n", desktop_icon_value_original);
-            if (!write_edited_desktop_file(key_file, path, desktop_filename, 2, md5, verbose, desktop_file_path)) {
+            if (!write_edited_desktop_file(key_file, path, desktop_filename, 2, md5, verbose)) {
 #ifdef STANDALONE
                 fprintf(stderr, "Failed to install desktop file\n");
 #endif
@@ -1242,10 +1233,6 @@ bool appimage_type2_register_in_system_get_desktop_file_path(const char* path, g
     g_free(md5);
     g_free(desktop_icon_value_original);
     return TRUE;
-}
-
-bool appimage_type2_register_in_system(const char* path, gboolean verbose) {
-    return appimage_type2_register_in_system_get_desktop_file_path(path, verbose, NULL);
 }
 
 /* Check whether AppImage is registered in the system already */
@@ -1377,9 +1364,8 @@ bool appimage_is_registered_in_system(const char* path) {
 /*
  * Register an AppImage in the system
  * Returns 0 on success, non-0 otherwise.
- * Set app_for_removal to add a [Desktop Action] for removing the AppImage using that executable.
  */
-int appimage_register_in_system_get_desktop_file_path(const char* path, gboolean verbose, const char* get_desktop_file_path)
+int appimage_register_in_system(char *path, gboolean verbose)
 {
     if((g_str_has_suffix(path, ".part")) ||
         g_str_has_suffix(path, ".tmp") ||
@@ -1405,12 +1391,10 @@ int appimage_register_in_system_get_desktop_file_path(const char* path, gboolean
 
     switch (type) {
         case 1:
-            if (!appimage_type1_register_in_system_get_desktop_file_path(path, verbose, get_desktop_file_path))
-                return 1;
+            appimage_type1_register_in_system(path, verbose);
             break;
         case 2:
-            if (!appimage_type2_register_in_system_get_desktop_file_path(path, verbose, get_desktop_file_path))
-                return 1;
+            appimage_type2_register_in_system(path, verbose);
             break;
         default:
 #ifdef STANDALONE
@@ -1419,15 +1403,17 @@ int appimage_register_in_system_get_desktop_file_path(const char* path, gboolean
             return 1;
     }
 
-    return 0;
-}
+    if (type == 1) {
+        if (!appimage_type1_register_in_system(path, verbose))
+            return 1;
+    }
 
-/*
- * Register an AppImage in the system
- * Returns 0 on success, non-0 otherwise.
- */
-int appimage_register_in_system(char* path, gboolean verbose) {
-    return appimage_register_in_system_get_desktop_file_path(path, verbose, NULL);
+    if (type == 2) {
+        if (!appimage_type2_register_in_system(path, verbose))
+            return 1;
+    }
+
+    return 0;
 }
 
 /* Delete the thumbnail for a given file and size if it exists */
@@ -1543,21 +1529,15 @@ void dummy_traverse_func(appimage_handler *handler, traverse_cb command, void *d
     (void) command;
     (void) data;
 
-#ifdef STANDALONE
     fprintf(stderr, "Called %s\n", __FUNCTION__);
-#endif
 }
 
 char* dummy_get_file_name (appimage_handler *handler, void *data) {
-#ifdef STANDALONE
     fprintf(stderr, "Called %s\n", __FUNCTION__);
-#endif
 }
 
 void dummy_extract_file(struct appimage_handler *handler, void *data, char *target) {
-#ifdef STANDALONE
     fprintf(stderr, "Called %s\n", __FUNCTION__);
-#endif
 }
 
 /*

--- a/src/shared.h
+++ b/src/shared.h
@@ -88,15 +88,12 @@ int appimage_register_in_system(char* path, gboolean verbose);
 
 void appimage_create_thumbnail(const gchar* appimage_file_path, gboolean verbose);
 
-bool appimage_type2_register_in_system_get_desktop_file_path(const char* path, gboolean verbose, char** desktop_file_path);
-
-bool appimage_type2_register_in_system(const char* path, gboolean verbose);
-
-bool appimage_type1_register_in_system_get_desktop_file_path(const char* path, gboolean verbose, char** desktop_file_path);
+bool appimage_type2_register_in_system(char* path, gboolean verbose);
 
 bool appimage_type1_register_in_system(const char* path, gboolean verbose);
 
-bool write_edited_desktop_file(GKeyFile* key_file_structure, const char* appimage_path, gchar* desktop_filename, int appimage_type, char* md5, gboolean verbose, char** desktop_file_path);
+bool write_edited_desktop_file(GKeyFile* key_file_structure, const char* appimage_path, gchar* desktop_filename,
+                               int appimage_type, char* md5, gboolean verbose);
 
 gboolean g_key_file_load_from_squash(sqfs* fs, char* path, GKeyFile* key_file_structure, gboolean verbose);
 

--- a/tests/test_libappimage.cpp
+++ b/tests/test_libappimage.cpp
@@ -1,6 +1,5 @@
 #include "appimage/appimage.h"
 
-#include <glob.h>
 #include <unistd.h>
 #include <sys/stat.h>
 
@@ -17,6 +16,7 @@
 
 
 namespace AppImageTests {
+
     class LibAppImageTest : public AppImageKitTest {
     protected:
         std::string appImage_type_1_file_path;
@@ -57,10 +57,6 @@ namespace AppImageTests {
             g_free(sum);
             return found;
         }
-
-        static bool compareStrings(const char* str1, const char* str2) {
-            return strcmp(str1, str2) == 0;
-        }
     };
 
     TEST_F(LibAppImageTest, appimage_get_type_invalid) {
@@ -91,22 +87,6 @@ namespace AppImageTests {
         appimage_unregister_in_system(appImage_type_2_file_path.c_str(), false);
     }
 
-    TEST_F(LibAppImageTest, appimage_register_in_system_with_type1_get_desktop_file_path) {
-        ASSERT_EQ(appimage_register_in_system(appImage_type_1_file_path.c_str(), false), 0);
-
-        ASSERT_TRUE(areIntegrationFilesDeployed(appImage_type_1_file_path));
-
-        appimage_unregister_in_system(appImage_type_1_file_path.c_str(), false);
-    }
-
-    TEST_F(LibAppImageTest, appimage_register_in_system_with_type2_get_desktop_file_path) {
-        ASSERT_EQ(appimage_register_in_system(appImage_type_2_file_path.c_str(), false), 0);
-
-        ASSERT_TRUE(areIntegrationFilesDeployed(appImage_type_2_file_path));
-
-        appimage_unregister_in_system(appImage_type_2_file_path.c_str(), false);
-    }
-
     TEST_F(LibAppImageTest, appimage_type1_register_in_system) {
         ASSERT_TRUE(appimage_type1_register_in_system(appImage_type_1_file_path.c_str(), false));
 
@@ -119,52 +99,6 @@ namespace AppImageTests {
         EXPECT_TRUE(appimage_type2_register_in_system(appImage_type_2_file_path.c_str(), false));
 
         EXPECT_TRUE(areIntegrationFilesDeployed(appImage_type_2_file_path));
-        appimage_unregister_in_system(appImage_type_2_file_path.c_str(), false);
-    }
-
-    TEST_F(LibAppImageTest, appimage_type1_register_in_system_get_desktop_file_path) {
-        char* desktop_file_path = NULL;
-        EXPECT_TRUE(appimage_type1_register_in_system_get_desktop_file_path(appImage_type_1_file_path.c_str(), false, &desktop_file_path));
-        EXPECT_TRUE(desktop_file_path != NULL);
-
-        glob_t pglob;
-
-        char* data_home = xdg_data_home();
-        std::string dirPath = std::string(data_home) + "/applications/*.desktop";
-        free(data_home);
-
-        EXPECT_EQ(glob(dirPath.c_str(), GLOB_NOSORT, NULL, &pglob), 0);
-        EXPECT_EQ(pglob.gl_pathc, 1);
-
-        if (pglob.gl_pathc >= 1) {
-            EXPECT_PRED2(compareStrings, pglob.gl_pathv[0], desktop_file_path);
-        }
-
-        globfree(&pglob);
-
-        appimage_unregister_in_system(appImage_type_1_file_path.c_str(), false);
-}
-
-    TEST_F(LibAppImageTest, appimage_type2_register_in_system_get_desktop_file_path) {
-        char* desktop_file_path = NULL;
-        EXPECT_TRUE(appimage_type2_register_in_system_get_desktop_file_path(appImage_type_2_file_path.c_str(), false, &desktop_file_path));
-        EXPECT_TRUE(desktop_file_path != NULL);
-
-        glob_t pglob;
-
-        char* data_home = xdg_data_home();
-        std::string dirPath = std::string(data_home) + "/applications/*.desktop";
-        free(data_home);
-
-        EXPECT_EQ(glob(dirPath.c_str(), GLOB_NOSORT, NULL, &pglob), 0);
-        EXPECT_EQ(pglob.gl_pathc, 1);
-
-        if (pglob.gl_pathc >= 1) {
-            EXPECT_PRED2(compareStrings, pglob.gl_pathv[0], desktop_file_path);
-        }
-
-        globfree(&pglob);
-
         appimage_unregister_in_system(appImage_type_2_file_path.c_str(), false);
     }
 

--- a/tests/test_shared.cpp
+++ b/tests/test_shared.cpp
@@ -38,7 +38,7 @@ TEST_F(SharedCTest, test_write_desktop_file_exec) {
     gboolean success = g_key_file_load_from_data(keyFile, buffer.data(), buffer.size(), G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS, NULL);
 
     if (success) {
-        write_edited_desktop_file(keyFile, "testpath", strdup("abc"), 1, strdup("def"), false, NULL);
+        write_edited_desktop_file(keyFile, "testpath", strdup("abc"), 1, strdup("def"), false);
     }
 
     g_key_file_free(keyFile);


### PR DESCRIPTION
Will be replaced by a more efficient method.

Reverts AppImage/AppImageKit#733