### PR TITLE
Add appimage_registered_desktop_file_path

### DIFF
--- a/include/appimage/appimage.h
+++ b/include/appimage/appimage.h
@@ -12,6 +12,15 @@ char *appimage_get_md5(char const* path);
 /* Check if a file is an AppImage. Returns the image type if it is, or -1 if it isn't */
 int appimage_get_type(const char* path, bool verbose);
 
+/*
+ * Finds the desktop file of a registered AppImage and returns the path
+ * Returns NULL if the desktop file can't be found, which should only occur when the AppImage hasn't been registered yet
+ */
+char* appimage_registered_desktop_file_path(const char* path, char* md5, bool verbose);
+
+/*
+ * Check whether an AppImage has been registered in the system
+ */
 bool appimage_is_registered_in_system(const char* path);
 
 /* Register a type 1 AppImage in the system */

--- a/src/shared.h
+++ b/src/shared.h
@@ -82,6 +82,8 @@ void unregister_using_md5_id(const char* name, int level, char* md5, gboolean ve
 
 void delete_thumbnail(char* path, char* size, gboolean verbose);
 
+char* appimage_registered_desktop_file_path(const char* path, char* md5, bool verbose);
+
 bool appimage_is_registered_in_system(const char* path);
 
 int appimage_register_in_system(char* path, gboolean verbose);

--- a/tests/test_libappimage.cpp
+++ b/tests/test_libappimage.cpp
@@ -286,6 +286,79 @@ namespace AppImageTests {
             FAIL();
     }
 
+    TEST_F(LibAppImageTest, test_appimage_registered_desktop_file_path_not_registered) {
+        EXPECT_TRUE(appimage_registered_desktop_file_path(appImage_type_1_file_path.c_str(), NULL, false) == NULL);
+        EXPECT_TRUE(appimage_registered_desktop_file_path(appImage_type_2_file_path.c_str(), NULL, false) == NULL);
+    }
+
+    TEST_F(LibAppImageTest, test_appimage_registered_desktop_file_path_type1) {
+        EXPECT_TRUE(appimage_type1_register_in_system(appImage_type_1_file_path.c_str(), false));
+
+        char* desktop_file_path = appimage_registered_desktop_file_path(appImage_type_1_file_path.c_str(), NULL, false);
+
+        EXPECT_TRUE(desktop_file_path != NULL);
+
+        free(desktop_file_path);
+    }
+
+    TEST_F(LibAppImageTest, test_appimage_registered_desktop_file_path_type2) {
+        EXPECT_TRUE(appimage_type2_register_in_system(appImage_type_2_file_path.c_str(), false));
+
+        char* desktop_file_path = appimage_registered_desktop_file_path(appImage_type_2_file_path.c_str(), NULL, false);
+
+        EXPECT_TRUE(desktop_file_path != NULL);
+
+        free(desktop_file_path);
+    }
+
+    TEST_F(LibAppImageTest, test_appimage_registered_desktop_file_path_type1_precalculated_md5) {
+        EXPECT_TRUE(appimage_type1_register_in_system(appImage_type_1_file_path.c_str(), false));
+
+        char* md5 = appimage_get_md5(appImage_type_1_file_path.c_str());
+        char* desktop_file_path = appimage_registered_desktop_file_path(appImage_type_1_file_path.c_str(), md5, false);
+        free(md5);
+
+        EXPECT_TRUE(desktop_file_path != NULL);
+
+        free(desktop_file_path);
+    }
+
+    TEST_F(LibAppImageTest, test_appimage_registered_desktop_file_path_type2_precalculated_md5) {
+        EXPECT_TRUE(appimage_type2_register_in_system(appImage_type_2_file_path.c_str(), false));
+
+        char* md5 = appimage_get_md5(appImage_type_2_file_path.c_str());
+        char* desktop_file_path = appimage_registered_desktop_file_path(appImage_type_2_file_path.c_str(), md5, false);
+        free(md5);
+
+        EXPECT_TRUE(desktop_file_path != NULL);
+
+        free(desktop_file_path);
+    }
+
+    TEST_F(LibAppImageTest, test_appimage_registered_desktop_file_path_type1_wrong_md5) {
+        EXPECT_TRUE(appimage_type1_register_in_system(appImage_type_1_file_path.c_str(), false));
+
+        char* md5 = strdup("abcdefg");
+        char* desktop_file_path = appimage_registered_desktop_file_path(appImage_type_1_file_path.c_str(), md5, false);
+        free(md5);
+
+        EXPECT_TRUE(desktop_file_path == NULL);
+
+        free(desktop_file_path);
+    }
+
+    TEST_F(LibAppImageTest, test_appimage_registered_desktop_file_path_type2_wrong_md5) {
+        EXPECT_TRUE(appimage_type2_register_in_system(appImage_type_2_file_path.c_str(), false));
+
+        char* md5 = strdup("abcdefg");
+        char* desktop_file_path = appimage_registered_desktop_file_path(appImage_type_2_file_path.c_str(), md5, false);
+        free(md5);
+
+        EXPECT_TRUE(desktop_file_path == NULL);
+
+        free(desktop_file_path);
+    }
+
 } // namespace
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This new function uses glob() to find an AppImage's desktop file after registration in XDG_DATA_HOME. As the MD5 is supposed to be unique (collision resistant for our use case), this should work fine.
Instead of searching the AppImage's contents for the missing filename component, it is sufficient to just build a pattern for glob() using the MD5 hash of the AppImage, using a wildcard character in place of
the missing component. The glob() call should then return a single file path, which is returned by this function.