### PR TITLE
Include public header in shared.h

### DIFF
--- a/include/appimage/appimage.h
+++ b/include/appimage/appimage.h
@@ -45,7 +45,7 @@ void appimage_extract_file_following_symlinks(const char* appimage_file_path, co
 /* Create AppImage thumbnail according to
  * https://specifications.freedesktop.org/thumbnail-spec/0.8.0/index.html
  */
-void appimage_create_thumbnail(const char* appimage_file_path);
+void appimage_create_thumbnail(const char* appimage_file_path, bool verbose);
 
 /* List files contained in the AppImage file.
  * Returns: a newly allocated char** ended at NULL. If no files ware found also is returned a {NULL}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,10 @@ add_custom_target(runtime DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/runtime)
 add_subdirectory(xdg-basedir)
 
 
+# include public include directory to avoid having to maintain definitions in two places
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+
 # allow setting different path for mksquashfs after installation
 set(AUXILIARY_FILES_DESTINATION "lib/appimagekit" CACHE STRING "Target install directory for mksquashfs")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,16 +36,11 @@ add_custom_target(runtime DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/runtime)
 add_subdirectory(xdg-basedir)
 
 
-# include public include directory to avoid having to maintain definitions in two places
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
-
 # allow setting different path for mksquashfs after installation
 set(AUXILIARY_FILES_DESTINATION "lib/appimagekit" CACHE STRING "Target install directory for mksquashfs")
 
 
 add_library(libappimage SHARED
-    ${PROJECT_SOURCE_DIR}/include/appimage/appimage.h
     shared.c
     getsection.c
     notify.c
@@ -209,6 +204,11 @@ target_compile_definitions(appimaged
     PRIVATE -DAPPIMAGED=1
 )
 # TODO: remove -DAPPIMAGED=1, move these code snippets to appimaged's source code files
+
+target_include_directories(appimaged
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
+    INTERFACE $<INSTALL_INTERFACE:include/>
+)
 
 add_dependencies(appimaged squashfuse)
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -237,7 +237,7 @@ void move_icon_to_destination(gchar *icon_path, gboolean verbose)
 }
 
 /* Check if a file is an AppImage. Returns the image type if it is, or -1 if it isn't */
-int appimage_get_type(const char* path, gboolean verbose)
+int appimage_get_type(const char* path, bool verbose)
 {
     FILE *f = fopen(path, "rt");
     if (f != NULL)
@@ -1037,7 +1037,7 @@ bool archive_copy_icons_recursively_to_destination(struct archive** a, const gch
 }
 
 /* Register a type 1 AppImage in the system */
-bool appimage_type1_register_in_system(const char *path, gboolean verbose)
+bool appimage_type1_register_in_system(const char *path, bool verbose)
 {
 #ifdef STANDALONE
     fprintf(stderr, "ISO9660 based type 1 AppImage\n");
@@ -1157,7 +1157,7 @@ bool appimage_type2_get_desktop_filename_and_key_file(sqfs* fs, gchar** desktop_
 }
 
 /* Register a type 2 AppImage in the system */
-bool appimage_type2_register_in_system(char *path, gboolean verbose) {
+bool appimage_type2_register_in_system(const char *path, bool verbose) {
 #ifdef STANDALONE
     fprintf(stderr, "squashfs based type 2 AppImage\n");
 #endif
@@ -1314,7 +1314,7 @@ bool appimage_is_registered_in_system(const char* path) {
  * Register an AppImage in the system
  * Returns 0 on success, non-0 otherwise.
  */
-int appimage_register_in_system(char *path, gboolean verbose)
+int appimage_register_in_system(const char *path, bool verbose)
 {
     if((g_str_has_suffix(path, ".part")) ||
         g_str_has_suffix(path, ".tmp") ||
@@ -1420,7 +1420,7 @@ void unregister_using_md5_id(const char *name, int level, char* md5, gboolean ve
 
 
 /* Unregister an AppImage in the system */
-int appimage_unregister_in_system(char *path, gboolean verbose)
+int appimage_unregister_in_system(const char *path, bool verbose)
 {
     char *md5 = appimage_get_md5(path);
 
@@ -1838,7 +1838,7 @@ void extract_appimage_icon(appimage_handler *h, gchar *target) {
 /* Create AppImage thumbanil according to
  * https://specifications.freedesktop.org/thumbnail-spec/0.8.0/index.html
  */
-void appimage_create_thumbnail(const gchar *appimage_file_path, gboolean verbose) {
+void appimage_create_thumbnail(const char *appimage_file_path, bool verbose) {
     // extract AppImage icon to /tmp
     appimage_handler handler = create_appimage_handler(appimage_file_path);
 

--- a/src/shared.h
+++ b/src/shared.h
@@ -3,6 +3,9 @@
 #include <glib.h>
 #include <squashfuse.h>
 
+// include public header to avoid duplicate definitions of functions
+#include "appimage/appimage.h"
+
 /* AppImage generic handler calback to be used in algorithms */
 typedef void (*traverse_cb)(void *handler, void *entry_data, void *user_data);
 
@@ -18,9 +21,6 @@ struct appimage_handler
     void *cache;
     bool is_open;
 } typedef appimage_handler;
-
-void appimage_extract_file_following_symlinks(const gchar* appimage_file_path, const char* file_path,
-                                              const char* target_dir);
 
 void extract_appimage_icon(appimage_handler* h, gchar* target);
 
@@ -41,8 +41,6 @@ void appimage_type2_extract_file(appimage_handler* handler, void* data, const ch
 void appimage_type2_extract_file_following_symlinks(sqfs* fs, sqfs_inode* inode, const char* target);
 
 void appimage_type2_extract_regular_file(sqfs* fs, sqfs_inode* inode, const char* target);
-
-void appimage_type2_extract_symlink(sqfs* fs, sqfs_inode* inode, const char* target);
 
 void appimage_type2_extract_symlink(sqfs* fs, sqfs_inode* inode, const char* target);
 
@@ -76,23 +74,9 @@ void mk_base_dir(const char* target);
 
 bool is_handler_valid(const appimage_handler* handler);
 
-int appimage_unregister_in_system(char* path, gboolean verbose);
-
 void unregister_using_md5_id(const char* name, int level, char* md5, gboolean verbose);
 
 void delete_thumbnail(char* path, char* size, gboolean verbose);
-
-char* appimage_registered_desktop_file_path(const char* path, char* md5, bool verbose);
-
-bool appimage_is_registered_in_system(const char* path);
-
-int appimage_register_in_system(char* path, gboolean verbose);
-
-void appimage_create_thumbnail(const gchar* appimage_file_path, gboolean verbose);
-
-bool appimage_type2_register_in_system(char* path, gboolean verbose);
-
-bool appimage_type1_register_in_system(const char* path, gboolean verbose);
 
 bool write_edited_desktop_file(GKeyFile* key_file_structure, const char* appimage_path, gchar* desktop_filename,
                                int appimage_type, char* md5, gboolean verbose);
@@ -105,18 +89,12 @@ gchar** squash_get_matching_files_install_icons_and_mime_data(sqfs* fs, char* pa
 
 void squash_extract_inode_to_file(sqfs* fs, sqfs_inode* inode, const gchar* dest);
 
-int appimage_get_type(const char* path, gboolean verbose);
-
 void move_icon_to_destination(gchar* icon_path, gboolean verbose);
 
 char* get_thumbnail_path(const char* path, char* thumbnail_size, gboolean verbose);
-
-char* appimage_get_md5(const char* path);
 
 gchar* replace_str(const gchar* src, const gchar* find, const gchar* replace);
 
 void set_executable(const char* path, gboolean verbose);
 
 extern char* vendorprefix;
-
-char** appimage_list_files(const char* path);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,7 +51,14 @@ if(BUILD_TESTING)
         ${gtest_LIBRARIES}
     )
 
-    target_include_directories(test_shared PRIVATE ../src/)
+    target_include_directories(test_shared
+        # used to include shared.h
+        PRIVATE ${PROJECT_SOURCE_DIR}/src/
+        # need to include libappimage's header directory as well
+        # as we're building this test manually from the source files, we need to replicate the build settings of
+        # libappimage, appimagetool, ...
+        PRIVATE ${PROJECT_SOURCE_DIR}/include/
+    )
 
     add_dependencies(test_shared squashfuse)
 

--- a/tests/test_libappimage.cpp
+++ b/tests/test_libappimage.cpp
@@ -128,7 +128,7 @@ namespace AppImageTests {
     }
 
     TEST_F(LibAppImageTest, create_thumbnail_appimage_type_1) {
-        appimage_create_thumbnail(appImage_type_1_file_path.c_str());
+        appimage_create_thumbnail(appImage_type_1_file_path.c_str(), false);
 
         gchar *sum = appimage_get_md5(appImage_type_1_file_path.c_str());
 
@@ -147,7 +147,7 @@ namespace AppImageTests {
     }
 
     TEST_F(LibAppImageTest, create_thumbnail_appimage_type_2) {
-        appimage_create_thumbnail(appImage_type_2_file_path.c_str());
+        appimage_create_thumbnail(appImage_type_2_file_path.c_str(), false);
 
         gchar *sum = appimage_get_md5(appImage_type_2_file_path.c_str());
 


### PR DESCRIPTION
This deprecates all the duplicate definitions in shared.h, and avoids broken definitions in the public header appimage.h.

CC @azubieta 