### PR TITLE
Use setproctitle() with TARGET_APPIMAGE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,7 +231,7 @@ target_link_libraries(runtime-debug
     bsd
 )
 
-set_target_properties(runtime-debug PROPERTIES LINK_FLAGS "-ffunction-sections -fdata-sections -s -Wl,--gc-sections")
+set_target_properties(runtime-debug PROPERTIES LINK_FLAGS "-ffunction-sections -fdata-sections -Wl,--gc-sections")
 
 target_compile_options(runtime-debug
     PUBLIC -DGIT_COMMIT='${GIT_COMMIT}' -D_FILE_OFFSET_BITS=64

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -234,7 +234,7 @@ target_link_libraries(runtime-debug
 set_target_properties(runtime-debug PROPERTIES LINK_FLAGS "-ffunction-sections -fdata-sections -Wl,--gc-sections")
 
 target_compile_options(runtime-debug
-    PUBLIC -DGIT_COMMIT='${GIT_COMMIT}' -D_FILE_OFFSET_BITS=64
+    PUBLIC -DGIT_COMMIT="${GIT_COMMIT}" -D_FILE_OFFSET_BITS=64
 )
 
 if(APPIMAGEKIT_RUNTIME_ENABLE_SETPROCTITLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 find_package(Sanitizers)
 
+set(APPIMAGEKIT_RUNTIME_ENABLE_SETPROCTITLE OFF CACHE BOOL "Useful for $TARGET_APPIMAGE; see issue #763")
+
 # set up build script
 
 # if set to anything but ON, the magic bytes won't be embedded
@@ -234,6 +236,12 @@ set_target_properties(runtime-debug PROPERTIES LINK_FLAGS "-ffunction-sections -
 target_compile_options(runtime-debug
     PUBLIC -DGIT_COMMIT='${GIT_COMMIT}' -D_FILE_OFFSET_BITS=64
 )
+
+if(APPIMAGEKIT_RUNTIME_ENABLE_SETPROCTITLE)
+    target_compile_definitions(runtime-debug
+        PUBLIC -DENABLE_SETPROCTITLE
+    )
+endif()
 
 
 # install binaries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,6 +226,7 @@ target_link_libraries(runtime-debug
     libzlib
     libcairo
     ${CMAKE_DL_LIBS}
+    bsd
 )
 
 set_target_properties(runtime-debug PROPERTIES LINK_FLAGS "-ffunction-sections -fdata-sections -s -Wl,--gc-sections")

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -24,6 +24,11 @@ repo_root="@CMAKE_CURRENT_SOURCE_DIR@"
 small_FLAGS="-Os -ffunction-sections -fdata-sections"
 small_LDFLAGS="-s -Wl,--gc-sections"
 
+if [ "@APPIMAGEKIT_RUNTIME_ENABLE_SETPROCTITLE@" == "ON" ]; then
+    small_FLAGS="$SMALL_FLAGS -DENABLE_SETPROCTITLE"
+    small_LDFLAGS="$SMALL_LDFLAGS -lbsd"
+fi
+
 cd $repo_root
 git_version="@GIT_COMMIT@"
 
@@ -60,7 +65,7 @@ objcopy --add-section .sig_key=8192_blank_bytes \
 squashfuse_libs="@squashfuse_LIBRARIES@"
 $CC $small_FLAGS $small_LDFLAGS -o runtime "$repo_root"/elf.c "$repo_root"/notify.c "$repo_root"/getsection.c \
     runtime4.o ${squashfuse_libs//;/ } \
-    -Wl,-Bdynamic -lpthread -l"@libzlib_LIBRARIES@" -L"@libzlib_LIBRARY_DIRS@" -Wl,-Bstatic "@xz_LIBRARIES@" -Wl,-Bdynamic -ldl -lbsd
+    -Wl,-Bdynamic -lpthread -l"@libzlib_LIBRARIES@" -L"@libzlib_LIBRARY_DIRS@" -Wl,-Bstatic "@xz_LIBRARIES@" -Wl,-Bdynamic -ldl
 $STRIP runtime
 
 # Test if we can read it back

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -60,7 +60,7 @@ objcopy --add-section .sig_key=8192_blank_bytes \
 squashfuse_libs="@squashfuse_LIBRARIES@"
 $CC $small_FLAGS $small_LDFLAGS -o runtime "$repo_root"/elf.c "$repo_root"/notify.c "$repo_root"/getsection.c \
     runtime4.o ${squashfuse_libs//;/ } \
-    -Wl,-Bdynamic -lpthread -l"@libzlib_LIBRARIES@" -L"@libzlib_LIBRARY_DIRS@" -Wl,-Bstatic "@xz_LIBRARIES@" -Wl,-Bdynamic -ldl
+    -Wl,-Bdynamic -lpthread -l"@libzlib_LIBRARIES@" -L"@libzlib_LIBRARY_DIRS@" -Wl,-Bstatic "@xz_LIBRARIES@" -Wl,-Bdynamic -ldl -lbsd
 $STRIP runtime
 
 # Test if we can read it back

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -37,8 +37,10 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/types.h>
-#include <bsd/unistd.h>
+#ifdef ENABLE_SETPROCTITLE
+    #include <sys/types.h>
+    #include <bsd/unistd.h>
+#endif
 #include <fcntl.h>
 #include <stdio.h>
 #include <signal.h>

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -37,6 +37,8 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <bsd/unistd.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <signal.h>
@@ -279,12 +281,22 @@ main (int argc, char *argv[])
      * change any time. Do not rely on it being present. We might even limit this
      * functionality specifically for builds used by appimaged.
      */
-    if(getenv("TARGET_APPIMAGE") == NULL){
+    if (getenv("TARGET_APPIMAGE") == NULL) {
         sprintf(appimage_path, "/proc/self/exe");
         sprintf(argv0_path, argv[0]);
     } else {
         sprintf(appimage_path, "%s", getenv("TARGET_APPIMAGE"));
         sprintf(argv0_path, getenv("TARGET_APPIMAGE"));
+
+        char buffer[1024];
+        strcpy(buffer, getenv("TARGET_APPIMAGE"));
+        for (int i = 1; i < argc; i++) {
+            strcat(buffer, " ");
+            strcat(buffer, argv[i]);
+        }
+
+        setproctitle_init(argc, argv, environ);
+        setproctitle("%s", buffer);
     }
 
     sprintf(argv0_path, argv[0]);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -288,6 +288,7 @@ main (int argc, char *argv[])
         sprintf(appimage_path, "%s", getenv("TARGET_APPIMAGE"));
         sprintf(argv0_path, getenv("TARGET_APPIMAGE"));
 
+#ifdef ENABLE_SETPROCTITLE
         char buffer[1024];
         strcpy(buffer, getenv("TARGET_APPIMAGE"));
         for (int i = 1; i < argc; i++) {
@@ -297,6 +298,7 @@ main (int argc, char *argv[])
 
         setproctitle_init(argc, argv, environ);
         setproctitle("%s", buffer);
+#endif
     }
 
     sprintf(argv0_path, argv[0]);


### PR DESCRIPTION
Fixes #763.

Uses libbsd's `setproctitle()` to override the process title when `$TARGET_APPIMAGE` is set. This allows users of `$TARGET_APPIMAGE` to differentiate between AppImages using the same runtime, as without this feature, the path to the actual AppImage isn't displayed in tools like `ps` or `[h]top`.

TODO:

  - check whether libbsd is an acceptable standard dependency, otherwise disable this functionality by default, and add a CMake option to enable it when necessary
  - check for libbsd dependency in CMake