### PR TITLE
Refactor get_elf_section_offset_and_length

### DIFF
--- a/include/appimage/appimage.h
+++ b/include/appimage/appimage.h
@@ -144,6 +144,11 @@ bool appimage_type2_digest_md5(const char* fname, char* digest);
  */
 char* appimage_hexlify(const char* bytes, size_t numBytes);
 
+/*
+ * Return the offset, and the length of an ELF section with a given name in a given ELF file
+ */
+bool appimage_get_elf_section_offset_and_length(const char* fname, const char* section_name, unsigned long* offset, unsigned long* length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -252,6 +252,11 @@ target_link_libraries(runtime-debug
 
 set_target_properties(runtime-debug PROPERTIES LINK_FLAGS "-ffunction-sections -fdata-sections -Wl,--gc-sections")
 
+target_include_directories(runtime-debug
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
+    INTERFACE $<INSTALL_INTERFACE:include/>
+)
+
 target_compile_options(runtime-debug
     PUBLIC -DGIT_COMMIT="${GIT_COMMIT}" -D_FILE_OFFSET_BITS=64
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,6 +226,11 @@ target_link_libraries(validate
     libopenssl
 )
 
+target_include_directories(validate
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
+    INTERFACE $<INSTALL_INTERFACE:include/
+)
+
 
 add_executable(digest digest.c getsection.c)
 

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -835,7 +835,13 @@ main (int argc, char *argv[])
           
             unsigned long ui_offset = 0;
             unsigned long ui_length = 0;
-            get_elf_section_offset_and_length(destination, ".upd_info", &ui_offset, &ui_length);
+
+            bool rv = appimage_get_elf_section_offset_and_length(destination, ".upd_info", &ui_offset, &ui_length);
+
+            if (!rv || ui_offset == 0 || ui_length == 0) {
+                die("Could not find section .upd_info in runtime");
+            }
+
             if(verbose) {
                 printf("ui_offset: %lu\n", ui_offset);
                 printf("ui_length: %lu\n", ui_length);
@@ -864,9 +870,9 @@ main (int argc, char *argv[])
             unsigned long digest_md5_offset = 0;
             unsigned long digest_md5_length = 0;
 
-            int rv = get_elf_section_offset_and_length(destination, ".digest_md5", &digest_md5_offset, &digest_md5_length);
+            bool rv = appimage_get_elf_section_offset_and_length(destination, ".digest_md5", &digest_md5_offset, &digest_md5_length);
 
-            if (rv != 0 || digest_md5_offset == 0 || digest_md5_length == 0) {
+            if (!rv || digest_md5_offset == 0 || digest_md5_length == 0) {
                 die("Could not find section .digest_md5 in runtime");
             }
 
@@ -1020,9 +1026,9 @@ main (int argc, char *argv[])
                     unsigned long sig_offset = 0;
                     unsigned long sig_length = 0;
 
-                    int rv = get_elf_section_offset_and_length(destination, ".sha256_sig", &sig_offset, &sig_length);
+                    bool rv = appimage_get_elf_section_offset_and_length(destination, ".sha256_sig", &sig_offset, &sig_length);
 
-                    if (rv != 0 || sig_offset == 0 || sig_length == 0) {
+                    if (!rv || sig_offset == 0 || sig_length == 0) {
                         die("Could not find section .sha256_sig in runtime");
                     }
 
@@ -1120,8 +1126,13 @@ main (int argc, char *argv[])
                 {
                     sprintf(command, "%s --batch --export --armor %s", gpg2_path, sign_key);
 
-                    unsigned long key_offset, key_length;
-                    int rv = get_elf_section_offset_and_length(destination, ".sig_key", &key_offset, &key_length);
+                    unsigned long key_offset = 0, key_length = 0;
+
+                    bool rv = appimage_get_elf_section_offset_and_length(destination, ".sig_key", &key_offset, &key_length);
+
+                    if (!rv || key_offset == 0 || key_length == 0) {
+                        die("Could not find section .sig_key in runtime");
+                    }
 
                     if (verbose) {
                         printf("key_offset: %lu\n", key_offset);

--- a/src/appimagetool_shared.c
+++ b/src/appimagetool_shared.c
@@ -61,15 +61,15 @@ int appimage_get_type(const char* path, bool verbose)
 bool appimage_type2_digest_md5(const char* path, char* digest) {
     // skip digest, signature and key sections in digest calculation
     unsigned long digest_md5_offset = 0, digest_md5_length = 0;
-    if (get_elf_section_offset_and_length(path, ".digest_md5", &digest_md5_offset, &digest_md5_length) != 0)
+    if (!appimage_get_elf_section_offset_and_length(path, ".digest_md5", &digest_md5_offset, &digest_md5_length))
         return false;
 
     unsigned long signature_offset = 0, signature_length = 0;
-    if (get_elf_section_offset_and_length(path, ".sha256_sig", &signature_offset, &signature_length) != 0)
+    if (!appimage_get_elf_section_offset_and_length(path, ".sha256_sig", &signature_offset, &signature_length))
         return false;
 
     unsigned long sig_key_offset = 0, sig_key_length = 0;
-    if (get_elf_section_offset_and_length(path, ".sig_key", &sig_key_offset, &sig_key_length) != 0)
+    if (!appimage_get_elf_section_offset_and_length(path, ".sig_key", &sig_key_offset, &sig_key_length))
         return false;
 
     GChecksum *checksum = g_checksum_new(G_CHECKSUM_MD5);

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -41,7 +41,7 @@ trap cleanup EXIT
 cd "$build_dir"
 
 # Compile runtime but do not link
-$CC -DGIT_COMMIT=\"$git_version\" -I"@xz_INCLUDE_DIRS@" -I"@squashfuse_INCLUDE_DIRS@" \
+$CC -DGIT_COMMIT=\"$git_version\" -I"@xz_INCLUDE_DIRS@" -I"@squashfuse_INCLUDE_DIRS@" -I"@PROJECT_SOURCE_DIR@/include" \
     -D_FILE_OFFSET_BITS=64 -g $small_FLAGS -c "$repo_root"/runtime.c
 
 # Prepare 16 bytes of space for MD5 digest section

--- a/src/digest.c
+++ b/src/digest.c
@@ -122,7 +122,7 @@ int main(int argc,char **argv)
     }
 
     if(argc < 4){
-        get_elf_section_offset_and_length(filename, ".sha256_sig", &skip_offset, &skip_length);
+        appimage_get_elf_section_offset_and_length(filename, ".sha256_sig", &skip_offset, &skip_length);
         if(skip_length > 0)
             fprintf(stderr, "Skipping ELF section %s with offset %lu, length %lu\n", segment_name, skip_offset, skip_length);
     } else if(argc == 4) {

--- a/src/digest_md5.c
+++ b/src/digest_md5.c
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
 
     static const char section_name[] = ".digest_md5";
 
-    if (get_elf_section_offset_and_length(fname, section_name, &offset, &length) != 0 || offset == 0 || length == 0) {
+    if (!appimage_get_elf_section_offset_and_length(fname, section_name, &offset, &length) || offset == 0 || length == 0) {
         fprintf(stderr, "Could not find %s section in file\n", section_name);
         return 1;
     }

--- a/src/getsection.c
+++ b/src/getsection.c
@@ -2,13 +2,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
+#include <stdbool.h>
 #include <string.h>
 #include <unistd.h>
 #include "light_elf.h"
 
 /* Return the offset, and the length of an ELF section with a given name in a given ELF file */
-int get_elf_section_offset_and_length(const char* fname, const char* section_name, unsigned long* offset,
-                                      unsigned long* length) {
+bool appimage_get_elf_section_offset_and_length(const char* fname, const char* section_name, unsigned long* offset, unsigned long* length) {
     uint8_t* data;
     int i;
     int fd = open(fname, O_RDONLY);
@@ -51,11 +51,11 @@ int get_elf_section_offset_and_length(const char* fname, const char* section_nam
     } else {
         sprintf(stderr, "Platforms other than 32-bit/64-bit are currently not supported!");
         munmap(data, map_size);
-        return 2;
+        return false;
     }
 
     munmap(data, map_size);
-    return 0;
+    return true;
 }
 
 char* read_file_offset_length(const char* fname, unsigned long offset, unsigned long length) {

--- a/src/getsection.h
+++ b/src/getsection.h
@@ -1,9 +1,6 @@
 #ifndef GETSECTION_H
 #define GETSECTION_H
 
-/* Return the offset, and the length of an ELF section with a given name in a given ELF file */
-int get_elf_section_offset_and_length(const char* fname, const char* section_name, unsigned long *offset, unsigned long *length);
-
 int print_hex(const char* fname, unsigned long offset, unsigned long length);
 
 int print_binary(const char* fname, unsigned long offset, unsigned long length);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -53,12 +53,12 @@
 #define ENABLE_DLOPEN
 #endif
 #include "squashfuse_dlopen.h"
+#include "appimage/appimage.h"
 
 #include <fnmatch.h>
 
 //#include "notify.c"
 extern int notify(char *title, char *body, int timeout);
-
 struct stat st;
 
 static ssize_t fs_offset; // The offset at which a filesystem image is expected = end of this ELF
@@ -459,7 +459,7 @@ main (int argc, char *argv[])
     if(arg && (strcmp(arg,"appimage-updateinformation")==0 || strcmp(arg,"appimage-updateinfo")==0)) {
         unsigned long offset = 0;
         unsigned long length = 0;
-        get_elf_section_offset_and_length(appimage_path, ".upd_info", &offset, &length);
+        appimage_get_elf_section_offset_and_length(appimage_path, ".upd_info", &offset, &length);
         // printf("offset: %lu\n", offset);
         // printf("length: %lu\n", length);
         // print_hex(appimage_path, offset, length);
@@ -470,7 +470,7 @@ main (int argc, char *argv[])
     if(arg && strcmp(arg,"appimage-signature")==0) {
         unsigned long offset = 0;
         unsigned long length = 0;
-        get_elf_section_offset_and_length(appimage_path, ".sha256_sig", &offset, &length);
+        appimage_get_elf_section_offset_and_length(appimage_path, ".sha256_sig", &offset, &length);
         // printf("offset: %lu\n", offset);
         // printf("length: %lu\n", length);
         // print_hex(appimage_path, offset, length);

--- a/src/shared.c
+++ b/src/shared.c
@@ -537,7 +537,7 @@ bool write_edited_desktop_file(GKeyFile *key_file_structure, const char* appimag
     if(g_find_program_in_path ("AppImageUpdate")){
         if(appimage_type == 2){
             if (!appimage_get_elf_section_offset_and_length(appimage_path, ".upd_info", &upd_offset, &upd_length) || upd_offset == 0 || upd_length == 0) {
-                fprintf("Could not read .upd_info section in AppImage's header\n");
+                fprintf(stderr, "Could not read .upd_info section in AppImage's header\n");
             }
             if(upd_length != 1024) {
 #ifdef STANDALONE

--- a/src/shared.c
+++ b/src/shared.c
@@ -536,7 +536,9 @@ bool write_edited_desktop_file(GKeyFile *key_file_structure, const char* appimag
     unsigned long upd_length = 0;
     if(g_find_program_in_path ("AppImageUpdate")){
         if(appimage_type == 2){
-            get_elf_section_offset_and_length(appimage_path, ".upd_info", &upd_offset, &upd_length);
+            if (!appimage_get_elf_section_offset_and_length(appimage_path, ".upd_info", &upd_offset, &upd_length) || upd_offset == 0 || upd_length == 0) {
+                fprintf("Could not read .upd_info section in AppImage's header\n");
+            }
             if(upd_length != 1024) {
 #ifdef STANDALONE
                 fprintf(stderr,

--- a/src/validate.c
+++ b/src/validate.c
@@ -16,6 +16,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 
+#include "appimage/appimage.h"
 #include "getsection.h"
 #include "light_elf.h"
 

--- a/src/validate.c
+++ b/src/validate.c
@@ -116,7 +116,11 @@ int main(int argc,char **argv)	{
     unsigned long skip_offset = 0;
     unsigned long skip_length = 0;
   
-    get_elf_section_offset_and_length(filename, ".sha256_sig", &skip_offset, &skip_length);
+    if (!appimage_get_elf_section_offset_and_length(filename, ".sha256_sig", &skip_offset, &skip_length)) {
+        fprintf(stderr, "Failed to read .sha256_sig section");
+        exit(1);
+    }
+
     if(skip_length > 0) {
         fprintf(stderr, "Skipping ELF section %s with offset %lu, length %lu\n", segment_name, skip_offset, skip_length);
     } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,7 +83,15 @@ if(BUILD_TESTING)
         gtest
     )
 
-    target_include_directories(test_getsection PRIVATE ../src/)
+    target_include_directories(test_getsection
+        # used to include getsection.h
+        PRIVATE ${PROJECT_SOURCE_DIR}/src/
+        # need to include libappimage's header directory as well
+        # as we're building this test manually from the source files, we need to replicate the build settings of
+        # libappimage, appimagetool, ...
+        PRIVATE ${PROJECT_SOURCE_DIR}/include/
+    )
+
 
     add_dependencies(test_getsection squashfuse)
 

--- a/tests/test_getsection.cpp
+++ b/tests/test_getsection.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 // local headers
+#include <appimage/appimage.h>
 #include "fixtures.h"
 
 extern "C" {

--- a/tests/test_getsection.cpp
+++ b/tests/test_getsection.cpp
@@ -24,12 +24,12 @@ bool isPowerOfTwo(int number) {
 }
 
 
-TEST_F(GetSectionCTest, test_get_elf_section_offset_and_length) {
+TEST_F(GetSectionCTest, test_appimage_get_elf_section_offset_and_length) {
     std::string appImagePath = std::string(TEST_DATA_DIR) + "/appimaged-i686.AppImage";
 
     unsigned long offset, length;
 
-    ASSERT_EQ(get_elf_section_offset_and_length(appImagePath.c_str(), ".upd_info", &offset, &length), 0);
+    ASSERT_EQ(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".upd_info", &offset, &length), 0);
 
     EXPECT_GT(offset, 0);
     EXPECT_GT(length, 0);
@@ -43,7 +43,7 @@ TEST_F(GetSectionCTest, test_print_binary) {
 
     unsigned long offset, length;
 
-    ASSERT_EQ(get_elf_section_offset_and_length(appImagePath.c_str(), ".upd_info", &offset, &length), 0);
+    ASSERT_EQ(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".upd_info", &offset, &length), 0);
 
     EXPECT_EQ(print_binary(appImagePath.c_str(), offset, length), 0);
 }
@@ -54,7 +54,7 @@ TEST_F(GetSectionCTest, test_print_hex) {
 
     unsigned long offset, length;
 
-    ASSERT_EQ(get_elf_section_offset_and_length(appImagePath.c_str(), ".sha256_sig", &offset, &length), 0);
+    ASSERT_EQ(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".sha256_sig", &offset, &length), 0);
 
     EXPECT_EQ(print_hex(appImagePath.c_str(), offset, length), 0);
 }

--- a/tests/test_getsection.cpp
+++ b/tests/test_getsection.cpp
@@ -30,7 +30,7 @@ TEST_F(GetSectionCTest, test_appimage_get_elf_section_offset_and_length) {
 
     unsigned long offset, length;
 
-    ASSERT_EQ(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".upd_info", &offset, &length), 0);
+    ASSERT_TRUE(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".upd_info", &offset, &length));
 
     EXPECT_GT(offset, 0);
     EXPECT_GT(length, 0);
@@ -44,7 +44,7 @@ TEST_F(GetSectionCTest, test_print_binary) {
 
     unsigned long offset, length;
 
-    ASSERT_EQ(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".upd_info", &offset, &length), 0);
+    ASSERT_TRUE(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".upd_info", &offset, &length));
 
     EXPECT_EQ(print_binary(appImagePath.c_str(), offset, length), 0);
 }
@@ -55,7 +55,7 @@ TEST_F(GetSectionCTest, test_print_hex) {
 
     unsigned long offset, length;
 
-    ASSERT_EQ(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".sha256_sig", &offset, &length), 0);
+    ASSERT_TRUE(appimage_get_elf_section_offset_and_length(appImagePath.c_str(), ".sha256_sig", &offset, &length));
 
     EXPECT_EQ(print_hex(appImagePath.c_str(), offset, length), 0);
 }


### PR DESCRIPTION
Provides this nice and useful function in libappimage. Useful e.g., to read contents of the AppImage specific sections in the AppImage header.