### PR TITLE
Fix ld not preserving ELF flags

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -60,8 +60,8 @@
 
 #ifdef __linux__
 #define HAVE_BINARY_RUNTIME
-extern int _binary_runtime_start;
-extern int _binary_runtime_end;
+extern char runtime[];
+extern unsigned int runtime_len;
 #endif
 
 enum fARCH { 
@@ -743,8 +743,8 @@ main (int argc, char *argv[])
 #ifdef HAVE_BINARY_RUNTIME
             /* runtime is embedded into this executable
             * http://stupefydeveloper.blogspot.de/2008/08/cc-embed-binary-data-into-elf.html */
-            size = (int)((void *)&_binary_runtime_end - (void *)&_binary_runtime_start);
-            data = (char *)&_binary_runtime_start;
+            size = runtime_len;
+            data = runtime;
 #else
             die("No runtime file was provided");
 #endif

--- a/src/appimagetoolnoglib.c
+++ b/src/appimagetoolnoglib.c
@@ -19,8 +19,8 @@
 
 #include <stdio.h>
 
-extern int _binary_runtime_start;
-extern int _binary_runtime_size;
+extern char runtime[];
+extern unsigned int runtime_len;
 
 
 const char *argp_program_version =
@@ -254,8 +254,8 @@ int main (int argc, char **argv)
 
       /* runtime is embedded into this executable
        * http://stupefydeveloper.blogspot.de/2008/08/cc-embed-binary-data-into-elf.html */
-      int size = (int)&_binary_runtime_size;
-      char *data = (char *)&_binary_runtime_start;
+      int size = runtime_len;
+      char *data = runtime;
       if (arguments.verbose)
           printf("Size of the embedded runtime: %d bytes\n", size);
       /* Where to store updateinformation. Fixed offset preferred for easy manipulation 

--- a/src/build-runtime.sh.in
+++ b/src/build-runtime.sh.in
@@ -89,7 +89,7 @@ if [ "@APPIMAGEKIT_EMBED_MAGIC_BYTES@" == "ON" ]; then
 fi
 
 # Convert runtime into a data object that can be embedded into appimagetool
-ld -r -b binary -o data.o runtime
+xxd -i runtime | $CC -c -x c - -o data.o
 
 # Show header for debugging purposes
 xxd runtime | head -n 1


### PR DESCRIPTION
https://github.com/AppImage/AppImageKit/blob/d38c4bc1f369785d8314bf65fde9856f86c25bf2/src/build-runtime.sh.in#L92

the `ld -r -b binary` command doesn't preserve ELF flags, which on some architectures are used to indicate architecture revisions, which might not be compatible between each other. This results in `appimagetool.c.o` being an ELF with flags set, but `data.o` an ELF with no flags set. If the version with flags and without are incompatible, which is the case with mips64el, the linker will error when trying to link them together:

```
[ 77%] Linking C executable appimagetool
cd /repo/build/AppImageKit/build/src && /usr/bin/cmake -E cmake_link_script CMakeFiles/appimagetool.dir/link.txt --verbose=1
/usr/bin/mips64el-linux-gnuabi64-gcc  -O3 -DNDEBUG   CMakeFiles/appimagetool.dir/appimagetool.c.o CMakeFiles/appimagetool.dir/getsection.c.o CMakeFiles/appimagetool.dir/binreloc.c.o CMakeFiles/appimagetool.dir/elf.c.o CMakeFiles/appimagetool.dir/appimagetool_shared.c.o data.o  -o appimagetool -rdynamic -ldl xdg-basedir/libxdg-basedir.a -lpthread ../squashfuse-EXTERNAL-prefix/src/squashfuse-EXTERNAL/.libs/libsquashfuse.a ../squashfuse-EXTERNAL-prefix/src/squashfuse-EXTERNAL/.libs/libsquashfuse_ll.a ../squashfuse-EXTERNAL-prefix/src/squashfuse-EXTERNAL/.libs/libfuseprivate.a -Wl,-Bstatic -llzma -Wl,-Bdynamic -lgobject-2.0 -lglib-2.0 -lz 
/usr/lib/gcc-cross/mips64el-linux-gnuabi64/6/../../../../mips64el-linux-gnuabi64/bin/ld: data.o: warning: linking abicalls files with non-abicalls files
/usr/lib/gcc-cross/mips64el-linux-gnuabi64/6/../../../../mips64el-linux-gnuabi64/bin/ld: data.o: linking 32-bit code with 64-bit code
/usr/lib/gcc-cross/mips64el-linux-gnuabi64/6/../../../../mips64el-linux-gnuabi64/bin/ld: failed to merge target specific data of file data.o
collect2: error: ld returned 1 exit status
src/CMakeFiles/appimagetool.dir/build.make:214: recipe for target 'src/appimagetool' failed
make[2]: *** [src/appimagetool] Error 1
make[2]: Leaving directory '/repo/build/AppImageKit/build'
CMakeFiles/Makefile2:1179: recipe for target 'src/CMakeFiles/appimagetool.dir/all' failed
make[1]: *** [src/CMakeFiles/appimagetool.dir/all] Error 2
make[1]: Leaving directory '/repo/build/AppImageKit/build'
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
```

Because `data.o` didn't have any ELF flags set, linker mistakenly thought it was a 32-bit binary and refused to link it with `appimagetool.c.o` which is 64-bit.

Here is the `data.o` from the above error message, you can see it's ELF64 MIPS, but the Flags field is set to 0x0 due to the use of `ld` (`mips64el-linux-gnuabi64-ld`, actually) command to create it, which is incorrect:

```sh
root@b31912c43724:/# mips64el-linux-gnuabi64-readelf -Wh /repo/build/AppImageKit/build/src/data.o 
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              REL (Relocatable file)
  Machine:                           MIPS R3000
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          0 (bytes into file)
  Start of section headers:          142976 (bytes into file)
  Flags:                             0x0
  Size of this header:               64 (bytes)
  Size of program headers:           0 (bytes)
  Number of program headers:         0
  Size of section headers:           64 (bytes)
  Number of section headers:         5
  Section header string table index: 4
```

Here is the `appimagetool.c.o` from that error message, ELF64 MIPS too, but with Flags field set correctly:

```sh
root@b31912c43724:/repo/build/AppImageKit/build# mips64el-linux-gnuabi64-readelf -Wh ./src/CMakeFiles/appimagetool.dir/appimagetool.c.o
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              REL (Relocatable file)
  Machine:                           MIPS R3000
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          0 (bytes into file)
  Start of section headers:          66840 (bytes into file)
  Flags:                             0x80000007, noreorder, pic, cpic, mips64r2
  Size of this header:               64 (bytes)
  Size of program headers:           0 (bytes)
  Number of program headers:         0
  Size of section headers:           64 (bytes)
  Number of section headers:         21
  Section header string table index: 20
```

Using 

```sh
xxd -i runtime | $CC -c -x c - -o data.o
```

instead of

```sh
ld -r -b binary -o data.o runtime
```

does preserve the ELF flags, fixing the issue. This solution was actually suggested in [a Debian bug report](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=827525) that I found when looking up the error message, it describes exactly the same issue as I do here and provides a similar patch.

After applying changes from this PR you get this `data.o` with preserved flags, just like it should be:

```sh
root@aaa25cdb1714:/repo/build# mips64el-linux-gnuabi64-readelf -Wh /repo/build/AppImageKit/build/src/data.o 
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              REL (Relocatable file)
  Machine:                           MIPS R3000
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          0 (bytes into file)
  Start of section headers:          143344 (bytes into file)
  Flags:                             0x80000006, pic, cpic, mips64r2
  Size of this header:               64 (bytes)
  Size of program headers:           0 (bytes)
  Number of program headers:         0
  Size of section headers:           64 (bytes)
  Number of section headers:         13
  Section header string table index: 12
```

Note that because we use a different command to generate `data.o`, the names of the exported symbols changed and there is no longer `_end` pointer, it's just an array and its size. The types of the exported symbols changed too, they used to be pointers, but now they are just C array and an integer, not pointers to them, so you don't need to deference them anymore. That explains the changes in the `.c` files.

I have tested this change and it seems to work fine for me. My Qt AppImage app built for x86_64 arch runs fine, and the mips64el build is now fixed and even creates a valid ELF AppImage file, altough I haven't tried running it.