### PR TITLE
Reap defunct child process

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -561,6 +561,8 @@ main (int argc, char *argv[])
         /* Pause until mounted */
         read (keepalive_pipe[0], &c, 1);
 
+        /* Fuse process has now daemonized, reap our child */
+        waitpid(pid, NULL, 0);
 
         dir_fd = open (mount_dir, O_RDONLY);
         if (dir_fd == -1) {


### PR DESCRIPTION
Payload software that calls `wait()` or `waitpid(-1, ...)` may be
confused if it is told about a defunct child process from the AppImage
runtime.

Fixes #812