### PR TITLE
Handle hardlinks during extraction.

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -464,6 +464,10 @@ main (int argc, char *argv[])
         }
         if (err)
             die("sqfs_traverse_next error");
+        for (int i = 0; i < fs.sb.inodes; i++) {
+            free(created_inode[i]);
+        }
+        free(created_inode);
         sqfs_traverse_close(&trv);
         sqfs_fd_close(fs.fd);
         exit(0);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -414,11 +414,11 @@ main (int argc, char *argv[])
                         }
                     } else if(inode.base.inode_type == SQUASHFS_REG_TYPE || inode.base.inode_type == SQUASHFS_LREG_TYPE){
                         // if we've already created this inode, then this is a hardlink
-                        char* exiting_path_for_inode = created_inode[inode.base.inode_number - 1];
-                        if(exiting_path_for_inode) {
+                        char* existing_path_for_inode = created_inode[inode.base.inode_number - 1];
+                        if(existing_path_for_inode) {
                             unlink(prefixed_path_to_extract);
-                            if(link(exiting_path_for_inode, prefixed_path_to_extract) == -1) {
-                                fprintf(stderr, "Couldn't create hardlink from \"%s\" to \"%s\": %s\n", prefixed_path_to_extract, exiting_path_for_inode, strerror(errno));
+                            if(link(existing_path_for_inode, prefixed_path_to_extract) == -1) {
+                                fprintf(stderr, "Couldn't create hardlink from \"%s\" to \"%s\": %s\n", prefixed_path_to_extract, existing_path_for_inode, strerror(errno));
                                 // fallthrow and follow the extract logic in the hope that it will work
                             } else {
                                 continue;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -420,7 +420,7 @@ main (int argc, char *argv[])
                             unlink(prefixed_path_to_extract);
                             if(link(existing_path_for_inode, prefixed_path_to_extract) == -1) {
                                 fprintf(stderr, "Couldn't create hardlink from \"%s\" to \"%s\": %s\n", prefixed_path_to_extract, existing_path_for_inode, strerror(errno));
-                                // fallthrow and follow the extract logic in the hope that it will work
+                                exit(EXIT_FAILURE);
                             } else {
                                 continue;
                             }

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -385,7 +385,8 @@ main (int argc, char *argv[])
         if(created_inode != NULL) {
             memset(created_inode, 0, fs.sb.inodes * sizeof(char *));
         } else {
-            fprintf(stderr, "Can't track hardlinks.\n");
+            fprintf(stderr, "Failed allocating memory to track hardlinks.\n");
+            exit(1);
         }
 
         if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -415,7 +415,7 @@ main (int argc, char *argv[])
                     } else if(inode.base.inode_type == SQUASHFS_REG_TYPE || inode.base.inode_type == SQUASHFS_LREG_TYPE){
                         // if we've already created this inode, then this is a hardlink
                         char* existing_path_for_inode = created_inode[inode.base.inode_number - 1];
-                        if(existing_path_for_inode) {
+                        if(existing_path_for_inode != NULL) {
                             unlink(prefixed_path_to_extract);
                             if(link(existing_path_for_inode, prefixed_path_to_extract) == -1) {
                                 fprintf(stderr, "Couldn't create hardlink from \"%s\" to \"%s\": %s\n", prefixed_path_to_extract, existing_path_for_inode, strerror(errno));


### PR DESCRIPTION
The runtime extract current code doesn't handle hardlinks explicitly and will extract a hardlinked file multiple times.

This PR copies the unsquashfs logic to do so.

(The code itself might be terrible :-s but it was mostly just a transplant so hopefully it's not too bad....)

(My understanding is that we're in a world of hurt if the malloc on 383 failed? But... I wasn't sure whether to forcibly exit or not...)