### PR TITLE
Revert "Bundle file command (quick fix for #590)"

### DIFF
--- a/build-appdir.sh
+++ b/build-appdir.sh
@@ -21,8 +21,6 @@ cp install_prefix/usr/lib/appimagekit/mksquashfs "$APPIMAGETOOL_APPDIR"/usr/lib/
 cp $(which desktop-file-validate) "$APPIMAGETOOL_APPDIR"/usr/bin/
 cp $(which zsyncmake) "$APPIMAGETOOL_APPDIR"/usr/bin/
 
-cp -f /usr/bin/file "$APPIMAGETOOL_APPDIR"/usr/bin
-
 cp ../resources/appimagetool.desktop "$APPIMAGETOOL_APPDIR"
 cp ../resources/appimagetool.svg "$APPIMAGETOOL_APPDIR"/appimagetool.svg
 ln -s "$APPIMAGETOOL_APPDIR"/appimagetool.svg "$APPIMAGETOOL_APPDIR"/.DirIcon


### PR DESCRIPTION
Reverts AppImage/AppImageKit#692

This causes _by far_ more problems than it solves. Only because a single niche distro doesn't ship with `file` doesn't mean we should break all the other distros by shipping an incompatible version of `file`.

The proper way to solve #590 is to remove the dependency on this command.