### PR TITLE
Mount within TMPDIR when environment variable is set

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -714,15 +714,20 @@ int main(int argc, char *argv[]) {
 
     int dir_fd, res;
 
+    char temp_base[PATH_MAX] = "/tmp";
+    if (getenv("TMPDIR") != NULL)
+      strcpy(temp_base, getenv("TMPDIR"));
+    size_t templen = strlen(temp_base);
     char mount_dir[64];
     size_t namelen = strlen(basename(argv[0]));
     if(namelen>6){
         namelen=6;
     }
-    strncpy(mount_dir, "/tmp/.mount_", 12);
-    strncpy(mount_dir+12, basename(argv[0]), namelen);
-    strncpy(mount_dir+12+namelen, "XXXXXX", 6);
-    mount_dir[12+namelen+6] = 0; // null terminate destination
+    strcpy(mount_dir, temp_base);
+    strncpy(mount_dir+templen, "/.mount_", 8);
+    strncpy(mount_dir+templen+8, basename(argv[0]), namelen);
+    strncpy(mount_dir+templen+8+namelen, "XXXXXX", 6);
+    mount_dir[templen+8+namelen+6] = 0; // null terminate destination
 
     char filename[100]; /* enough for mount_dir + "/AppRun" */
     pid_t pid;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -719,11 +719,16 @@ int main(int argc, char *argv[]) {
     int dir_fd, res;
 
     size_t templen = strlen(temp_base);
+
+    // allocate enough memory (size of name won't exceed 60 bytes)
     char mount_dir[templen + 60];
+
     size_t namelen = strlen(basename(argv[0]));
-    if(namelen>6){
-        namelen=6;
+    // limit length of tempdir name
+    if(namelen > 6){
+        namelen = 6;
     }
+
     strcpy(mount_dir, temp_base);
     strncpy(mount_dir+templen, "/.mount_", 8);
     strncpy(mount_dir+templen+8, basename(argv[0]), namelen);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -864,7 +864,7 @@ int main(int argc, char *argv[]) {
         }
 
         char filename[mount_dir_size + 8]; /* enough for mount_dir + "/AppRun" */
-        strcpy (3, mount_dir);
+        strcpy (filename, mount_dir);
         strcat (filename, "/AppRun");
 
         /* TODO: Find a way to get the exit status and/or output of this */

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -529,6 +529,16 @@ int main(int argc, char *argv[]) {
 #endif
     }
 
+    // temporary directories are required in a few places
+    // therefore we implement the detection of the temp base dir at the top of the code to avoid redundancy
+    char temp_base[PATH_MAX] = P_tmpdir;
+
+    {
+        const char* const TMPDIR = getenv("TMPDIR");
+        if (TMPDIR != NULL)
+            strcpy(temp_base, getenv("TMPDIR"));
+    }
+
     fs_offset = appimage_get_elf_size(appimage_path);
 
     // error check
@@ -585,13 +595,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (arg && strcmp(arg, "appimage-extract-and-run") == 0) {
-        char temp_base[PATH_MAX] = P_tmpdir;
-
-        const char* const TMPDIR = getenv("TMPDIR");
-        if (TMPDIR != NULL)
-            strcpy(temp_base, getenv("TMPDIR"));
-
-        char* hexlified_digest;
+        char* hexlified_digest = NULL;
 
         // calculate MD5 hash of file, and use it to make extracted directory name "content-aware"
         // see https://github.com/AppImage/AppImageKit/issues/841 for more information
@@ -714,9 +718,6 @@ int main(int argc, char *argv[]) {
 
     int dir_fd, res;
 
-    char temp_base[PATH_MAX] = P_tmpdir;
-    if (getenv("TMPDIR") != NULL)
-      strcpy(temp_base, getenv("TMPDIR"));
     size_t templen = strlen(temp_base);
     char mount_dir[templen + 60];
     size_t namelen = strlen(basename(argv[0]));

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -730,7 +730,6 @@ int main(int argc, char *argv[]) {
     mount_dir[templen+8+namelen+6] = 0; // null terminate destination
 
     size_t mount_dir_size = strlen(mount_dir);
-    char filename[mount_dir_size + 8]; /* enough for mount_dir + "/AppRun" */
     pid_t pid;
     char **real_argv;
     int i;
@@ -806,9 +805,6 @@ int main(int argc, char *argv[]) {
         }
         close (dir_fd);
 
-        strcpy (filename, mount_dir);
-        strcat (filename, "/AppRun");
-
         real_argv = malloc (sizeof (char *) * (argc + 1));
         for (i = 0; i < argc; i++) {
             real_argv[i] = argv[i];
@@ -865,6 +861,10 @@ int main(int argc, char *argv[]) {
         if (getcwd(cwd, sizeof(cwd)) != NULL) {
             setenv( "OWD", cwd, 1 );
         }
+
+        char filename[mount_dir_size + 8]; /* enough for mount_dir + "/AppRun" */
+        strcpy (3, mount_dir);
+        strcat (filename, "/AppRun");
 
         /* TODO: Find a way to get the exit status and/or output of this */
         execv (filename, real_argv);


### PR DESCRIPTION
Setting the TMPDIR environment variable to a custom value (anything not `/tmp`) results in errors when attempting to run the executable. The failure occurs in the `AppRun` script with the `grep` command being unable to find the `*.desktop` file. 

Digging into preload.c I found this which looks to be the culprit: https://github.com/mikix/deb2snap/blob/master/src/preload.c#L153 and explains why the actual path being used for the grep command _does_ exist but returns a no such file error. Updating the appimage mount to use TMPDIR as the base path when it is set resolves the issue and execution of the app is successful.