### PR TITLE
Fix exit status in various places

### DIFF
--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -24,7 +24,8 @@ if [ -e /usr/bin/apt-get ] ; then
   sudo apt-get -y install zsync git libarchive-dev autoconf libtool make gcc g++ libtool libfuse-dev \
   liblzma-dev libglib2.0-dev libssl-dev libinotifytools0-dev liblz4-dev libcairo-dev desktop-file-utils cmake
   # libtool-bin might be required in newer distributions but is not available in precise
-  sudo cp resources/liblz4.pc /usr/lib/$ARCH-linux-gnu/pkgconfig/
+  test -e /usr/lib/$ARCH-linux-gnu/pkgconfig/liblz4.pc ||
+    sudo cp -v resources/liblz4.pc /usr/lib/$ARCH-linux-gnu/pkgconfig/
   if cat /etc/lsb-release | grep 14.04 2>&1 >/dev/null; then
     export CMAKE_VERSION=3.10.0
     # sometimes, using a crowbar is easier than fiddling with PPAs

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -668,6 +668,7 @@ int main(int argc, char *argv[]) {
             fprintf(stderr, "Failed to run %s: %s\n", apprun_path, strerror(error));
 
             free(apprun_path);
+            exit(EXIT_EXECERROR);
         }
 
         int rv = waitpid(pid, NULL, 0);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -667,14 +667,14 @@ int main(int argc, char *argv[]) {
         if (getenv("NO_CLEANUP") == NULL) {
             if (!rm_recursive(prefix)) {
                 fprintf(stderr, "Failed to clean up cache directory\n");
-                rv = false;
+                rv = -1;
             }
         }
 
         // template == prefix, must be freed only once
         free(prefix);
 
-        exit(rv ? 0 : 1);
+        exit(rv >= 0 ? 0 : 1);
     }
 
     if(arg && strcmp(arg,"appimage-version")==0) {


### PR DESCRIPTION
This PR does a couple things:

- First, it prevents liblz4.pc from being overwritten on my system (Ubunto newer than 14.04), let me know if you need a separate PR for this as it's unrelated to the rest.

- Second, in cases where the AppImage runtime failed to launch the payload, we now return 127, similar to SYSTEM(3POSIX), to avoid cluttering meaningful exit status codes from applications.

- Third, it fixes a bug in --appimage-extract-and-run where an execv() error lead to duplicate execution of the parent's cleanup code.

- Fourth, it fixes --appimage-extract-and-run to not swallow the exit status of the payload (executed as a child process). If the child exits due to a signal or other abnormal condition, we return 127 again, but for normal exits, the child's exit status is preserved.

Let me know if you'd rather have this PR split.