### PR TITLE
Runtime: Allow recursive extraction of partial sections of the AppImage

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -318,7 +318,7 @@ bool extract_appimage(const char* const appimage_path, const char* const _prefix
 
     while (sqfs_traverse_next(&trv, &err)) {
         if (!trv.dir_end) {
-            if (_pattern == NULL || fnmatch(_pattern, trv.path, FNM_FILE_NAME) == 0) {
+            if (_pattern == NULL || fnmatch(_pattern, trv.path, FNM_FILE_NAME | FNM_LEADING_DIR) == 0) {
                 // fprintf(stderr, "trv.path: %s\n", trv.path);
                 // fprintf(stderr, "sqfs_inode_id: %lu\n", trv.entry.inode);
                 sqfs_inode inode;


### PR DESCRIPTION
Fix #370 

Allows
./my.AppImage --appimage-extract usr/share/icons

and all the files contained in that path will be extracted.