### PR TITLE
Only mount tmpfs to /tmp if it's not mounted yet

### DIFF
--- a/testappimage
+++ b/testappimage
@@ -35,7 +35,7 @@ mkdir -p /tmp/$PREF/iso
 mkdir -p /tmp/$PREF/workdir
 
 # openSUSE LEAP 42.2 does not have a tmpfs in /tmp but we need this
-mount | grep "/tmp type tmpfs" && sudo mount -t tmpfs tmpfs /tmp/
+mount | grep "/tmp type tmpfs" || sudo mount -t tmpfs tmpfs /tmp/
 
 # If ISO was specified, then mount it and find contained filesystem
 THEFS="$1"

--- a/testappimage
+++ b/testappimage
@@ -35,7 +35,7 @@ mkdir -p /tmp/$PREF/iso
 mkdir -p /tmp/$PREF/workdir
 
 # openSUSE LEAP 42.2 does not have a tmpfs in /tmp but we need this
-mount | grep "/tmp type tmpfs" || sudo mount -t tmpfs tmpfs /tmp/
+mount | grep -q "/tmp type tmpfs" || sudo mount -t tmpfs tmpfs /tmp/
 
 # If ISO was specified, then mount it and find contained filesystem
 THEFS="$1"


### PR DESCRIPTION
This is a logical error that renders the script non-working on Debian for instance. If grep returns true (i.e. /tmp is already mounted as tmpfs) lazy evaluation should skip the right part. If it returns false then we should mount /tmp. With && the logic is exactly the opposite. How was it working before?