### PR TITLE
0755 permissions for directories, addresses #1032

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -194,7 +194,7 @@ mkdir_p(const char* const path)
             /* Temporarily truncate */
             *p = '\0';
 
-            if (mkdir(_path, S_IRWXU) != 0) {
+            if (mkdir(_path, 0755) != 0) {
                 if (errno != EEXIST)
                     return -1;
             }
@@ -203,7 +203,7 @@ mkdir_p(const char* const path)
         }
     }
 
-    if (mkdir(_path, S_IRWXU) != 0) {
+    if (mkdir(_path, 0755) != 0) {
         if (errno != EEXIST)
             return -1;
     }


### PR DESCRIPTION
Addresses the bug reported by @bdantas:  `--appimage-extract` changes all directory permissions to `700`. This is unexpected and causes problems (if `squashfs-root` is used as-is to create a new AppImage, the new AppImage _must_ be mounted with `fuse` or else non-root user gets hit with "Permission denied"). 

Desired behavior: `--appimage-extract` should not change any permissions, so that the contents of `squashfs-root` match exactly what was in the original AppImage. 

Implemented here: Uses `0755`. Implementing the desired behavior is more work, feel free to send another PR to implement it. For now, I think this already improves the situation a bit.

Reference: https://github.com/AppImage/AppImageKit/issues/1032#issuecomment-597050268