### PR TITLE
Use mksquashfs instead of downloading during the build

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -33,7 +33,6 @@ set(LDFLAGS ${DEPENDENCIES_LDFLAGS})
 set(USE_SYSTEM_MKSQUASHFS OFF CACHE BOOL "Use system mksquashfs instead of downloading and building our own. Warning: you need a recent version otherwise it might not work as intended.")
 
 if(NOT USE_SYSTEM_MKSQUASHFS)
-    # TODO: allow using system wide mksquashfs
     set(mksquashfs_cflags "-DXZ_SUPPORT ${CFLAGS}")
 
     if(NOT xz_LIBRARIES OR xz_LIBRARIES STREQUAL "")

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,7 +30,7 @@ set(CFLAGS ${DEPENDENCIES_CFLAGS})
 set(CPPFLAGS ${DEPENDENCIES_CPPFLAGS})
 set(LDFLAGS ${DEPENDENCIES_LDFLAGS})
 
-set(USE_SYSTEM_MKSQUASHFS OFF CACHE BOOL "Use system mksquashfs instead of downloading and building our own")
+set(USE_SYSTEM_MKSQUASHFS OFF CACHE BOOL "Use system mksquashfs instead of downloading and building our own. Warning: you need a recent version otherwise it might not work as intended.")
 
 if(NOT USE_SYSTEM_MKSQUASHFS)
     # TODO: allow using system wide mksquashfs

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,49 +30,55 @@ set(CFLAGS ${DEPENDENCIES_CFLAGS})
 set(CPPFLAGS ${DEPENDENCIES_CPPFLAGS})
 set(LDFLAGS ${DEPENDENCIES_LDFLAGS})
 
+set(USE_SYSTEM_MKSQUASHFS OFF CACHE BOOL "Use system mksquashfs instead of downloading and building our own")
 
-# TODO: allow using system wide mksquashfs
-set(mksquashfs_cflags "-DXZ_SUPPORT ${CFLAGS}")
+if(NOT USE_SYSTEM_MKSQUASHFS)
+    # TODO: allow using system wide mksquashfs
+    set(mksquashfs_cflags "-DXZ_SUPPORT ${CFLAGS}")
 
-if(NOT xz_LIBRARIES OR xz_LIBRARIES STREQUAL "")
-    message(FATAL_ERROR "xz_LIBRARIES not set")
-elseif(xz_LIBRARIES MATCHES "\\.a$")
-    set(mksquashfs_ldflags "${xz_LIBRARIES}")
+    if(NOT xz_LIBRARIES OR xz_LIBRARIES STREQUAL "")
+        message(FATAL_ERROR "xz_LIBRARIES not set")
+    elseif(xz_LIBRARIES MATCHES "\\.a$")
+        set(mksquashfs_ldflags "${xz_LIBRARIES}")
+    else()
+        set(mksquashfs_ldflags "-l${xz_LIBRARIES}")
+    endif()
+
+    if(xz_INCLUDE_DIRS)
+        set(mksquashfs_cflags "${mksquashfs_cflags} -I${xz_INCLUDE_DIRS}")
+    endif()
+    if(xz_LIBRARY_DIRS)
+        set(mksquashfs_ldflags "${mksquashfs_ldflags} -L${xz_LIBRARY_DIRS}")
+    endif()
+
+    ExternalProject_Add(mksquashfs
+        GIT_REPOSITORY https://github.com/plougher/squashfs-tools/
+        GIT_TAG 4.4
+        UPDATE_COMMAND ""  # Make sure CMake won't try to fetch updates unnecessarily and hence rebuild the dependency every time
+        CONFIGURE_COMMAND ${SED} -i "s|CFLAGS += -DXZ_SUPPORT|CFLAGS += ${mksquashfs_cflags}|g" <SOURCE_DIR>/squashfs-tools/Makefile
+        COMMAND ${SED} -i "s|LIBS += -llzma|LIBS += -Bstatic ${mksquashfs_ldflags}|g" <SOURCE_DIR>/squashfs-tools/Makefile
+        COMMAND ${SED} -i "s|install: mksquashfs unsquashfs|install: mksquashfs|g" squashfs-tools/Makefile
+        COMMAND ${SED} -i "/cp unsquashfs/d" squashfs-tools/Makefile
+        BUILD_COMMAND env CC=${CC} CXX=${CXX} LDFLAGS=${LDFLAGS} ${MAKE} -C squashfs-tools/ XZ_SUPPORT=1 mksquashfs
+        # ${MAKE} install unfortunately expects unsquashfs to be built as well, hence can't install the binary
+        # therefore using built file in SOURCE_DIR
+        # TODO: implement building out of source
+        BUILD_IN_SOURCE ON
+        INSTALL_COMMAND ${MAKE} -C squashfs-tools/ install INSTALL_DIR=<INSTALL_DIR>
+    )
+
+    ExternalProject_Get_Property(mksquashfs INSTALL_DIR)
+    set(mksquashfs_INSTALL_DIR "${INSTALL_DIR}")
+    mark_as_advanced(mksquashfs_INSTALL_DIR)
+
+    # for later use when packaging as an AppImage
+    set(mksquashfs_BINARY "${mksquashfs_INSTALL_DIR}/mksquashfs")
+    mark_as_advanced(mksquashfs_BINARY)
 else()
-    set(mksquashfs_ldflags "-l${xz_LIBRARIES}")
+    message(STATUS "Using system mksquashfs")
+
+    set(mksquashfs_BINARY "mksquashfs")
 endif()
-
-if(xz_INCLUDE_DIRS)
-    set(mksquashfs_cflags "${mksquashfs_cflags} -I${xz_INCLUDE_DIRS}")
-endif()
-if(xz_LIBRARY_DIRS)
-    set(mksquashfs_ldflags "${mksquashfs_ldflags} -L${xz_LIBRARY_DIRS}")
-endif()
-
-ExternalProject_Add(mksquashfs
-    GIT_REPOSITORY https://github.com/plougher/squashfs-tools/
-    GIT_TAG 4.4
-    UPDATE_COMMAND ""  # Make sure CMake won't try to fetch updates unnecessarily and hence rebuild the dependency every time
-    CONFIGURE_COMMAND ${SED} -i "s|CFLAGS += -DXZ_SUPPORT|CFLAGS += ${mksquashfs_cflags}|g" <SOURCE_DIR>/squashfs-tools/Makefile
-    COMMAND ${SED} -i "s|LIBS += -llzma|LIBS += -Bstatic ${mksquashfs_ldflags}|g" <SOURCE_DIR>/squashfs-tools/Makefile
-    COMMAND ${SED} -i "s|install: mksquashfs unsquashfs|install: mksquashfs|g" squashfs-tools/Makefile
-    COMMAND ${SED} -i "/cp unsquashfs/d" squashfs-tools/Makefile
-    BUILD_COMMAND env CC=${CC} CXX=${CXX} LDFLAGS=${LDFLAGS} ${MAKE} -C squashfs-tools/ XZ_SUPPORT=1 mksquashfs
-    # ${MAKE} install unfortunately expects unsquashfs to be built as well, hence can't install the binary
-    # therefore using built file in SOURCE_DIR
-    # TODO: implement building out of source
-    BUILD_IN_SOURCE ON
-    INSTALL_COMMAND ${MAKE} -C squashfs-tools/ install INSTALL_DIR=<INSTALL_DIR>
-)
-
-ExternalProject_Get_Property(mksquashfs INSTALL_DIR)
-set(mksquashfs_INSTALL_DIR "${INSTALL_DIR}")
-mark_as_advanced(mksquashfs_INSTALL_DIR)
-
-# for later use when packaging as an AppImage
-set(mksquashfs_BINARY "${mksquashfs_INSTALL_DIR}/mksquashfs")
-mark_as_advanced(mksquashfs_BINARY)
-
 
 #### build dependency configuration ####
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,18 +117,20 @@ target_link_libraries(digest_md5
 
 
 # install binaries
-if(AUXILIARY_FILES_DESTINATION)
-    install(
-        PROGRAMS ${mksquashfs_INSTALL_DIR}/mksquashfs ${CMAKE_CURRENT_BINARY_DIR}/runtime
-        DESTINATION ${AUXILIARY_FILES_DESTINATION}
-        COMPONENT applications
-    )
-else()
-    install(
-        PROGRAMS ${mksquashfs_INSTALL_DIR}/mksquashfs ${CMAKE_CURRENT_BINARY_DIR}/runtime
-        DESTINATION bin
-        COMPONENT applications
-    )
+if(NOT USE_SYSTEM_MKSQUASHFS)
+    if(AUXILIARY_FILES_DESTINATION)
+        install(
+            PROGRAMS ${mksquashfs_INSTALL_DIR}/mksquashfs ${CMAKE_CURRENT_BINARY_DIR}/runtime
+            DESTINATION ${AUXILIARY_FILES_DESTINATION}
+            COMPONENT applications
+        )
+    else()
+        install(
+            PROGRAMS ${mksquashfs_INSTALL_DIR}/mksquashfs ${CMAKE_CURRENT_BINARY_DIR}/runtime
+            DESTINATION bin
+            COMPONENT applications
+        )
+    endif()
 endif()
 
 set(optional_targets "")


### PR DESCRIPTION
~~Required for https://github.com/AppImage/appimaged/issues/40.~~ Actually I am wrong. That silently moved to https://github.com/AppImage/appimaged. This change allows the AppImageKit to compile on @openSUSE build servers which disallow remote code downloading during the build for security reasons and the dependency should be unbundled anyway.