### PR TITLE
Fix Bug #949, "BAD signature" when validating

### DIFF
--- a/src/validate.c
+++ b/src/validate.c
@@ -137,6 +137,10 @@ int main(int argc,char **argv)	{
         fprintf(stderr, "ELF section %s not found, is the file signed?\n", segment_key_name);
         exit(1);
     }
+    if(skip_offset_sig + skip_length_sig != skip_offset_key) {
+      fprintf(stderr, "Validate only worlds when .sha256_sig and .sig_key are next to one another in the ELF\n");
+      exit(0);
+    }
     int skip_offset = skip_offset_sig;
     int skip_length = skip_length_sig + skip_length_key;
     

--- a/src/validate.c
+++ b/src/validate.c
@@ -121,8 +121,8 @@ int main(int argc,char **argv)	{
         exit(1);
     }
     if (!appimage_get_elf_section_offset_and_length(filename, ".sig_key", &skip_offset_key, &skip_length_key)) {
-      skip_length_key = 0;
-      skip_offset_key = 0;
+        skip_length_key = 0;
+        skip_offset_key = 0;
     }
 
     if(skip_length_sig > 0) {
@@ -137,8 +137,8 @@ int main(int argc,char **argv)	{
         fprintf(stderr, "ELF section %s not found, assuming older AppImage Standard\n", segment_key_name);
     }
     if(skip_offset_sig + skip_length_sig != skip_offset_key && skip_length_key != 0) {
-      fprintf(stderr, "Validate only worlds when .sha256_sig and .sig_key are next to one another in the ELF\n");
-      exit(0);
+        fprintf(stderr, "validate only works when .sha256_sig and .sig_key are contiguous in the ELF header\n");
+        exit(0);
     }
     int skip_offset = skip_offset_sig;
     int skip_length = skip_length_sig + skip_length_key;

--- a/src/validate.c
+++ b/src/validate.c
@@ -121,8 +121,8 @@ int main(int argc,char **argv)	{
         exit(1);
     }
     if (!appimage_get_elf_section_offset_and_length(filename, ".sig_key", &skip_offset_key, &skip_length_key)) {
-        fprintf(stderr, "Failed to read .sig_key section");
-        exit(1);
+      skip_length_key = 0;
+      skip_offset_key = 0;
     }
 
     if(skip_length_sig > 0) {
@@ -134,10 +134,10 @@ int main(int argc,char **argv)	{
     if(skip_length_key > 0) {
         fprintf(stderr, "Skipping ELF section %s with offset %lu, length %lu\n", segment_key_name, skip_offset_key, skip_length_key);
     } else {
-        fprintf(stderr, "ELF section %s not found, is the file signed?\n", segment_key_name);
+        fprintf(stderr, "ELF section %s not found, assuming older AppImage Standard\n", segment_key_name);
         exit(1);
     }
-    if(skip_offset_sig + skip_length_sig != skip_offset_key) {
+    if(skip_offset_sig + skip_length_sig != skip_offset_key && skip_length_key != 0) {
       fprintf(stderr, "Validate only worlds when .sha256_sig and .sig_key are next to one another in the ELF\n");
       exit(0);
     }

--- a/src/validate.c
+++ b/src/validate.c
@@ -135,7 +135,6 @@ int main(int argc,char **argv)	{
         fprintf(stderr, "Skipping ELF section %s with offset %lu, length %lu\n", segment_key_name, skip_offset_key, skip_length_key);
     } else {
         fprintf(stderr, "ELF section %s not found, assuming older AppImage Standard\n", segment_key_name);
-        exit(1);
     }
     if(skip_offset_sig + skip_length_sig != skip_offset_key && skip_length_key != 0) {
       fprintf(stderr, "Validate only worlds when .sha256_sig and .sig_key are next to one another in the ELF\n");


### PR DESCRIPTION
This was to fix [this][bug] bug.
Changes made:
- Looked for `.sig_key` part of ELF
- Added it to the length that is to be set to 0 in the hash

Currently, it works on the assumption that these parts are adjacent in the ELF.

[bug]: https://github.com/AppImage/AppImageKit/issues/949