### PR TITLE
Fix/wrong architecture string on appimagetool arch/1114

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -360,7 +360,8 @@ void extract_arch_from_text(gchar *archname, const gchar* sourcename, bool* arch
                 archs[fARCH_arm] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture ARM\n", sourcename);
-            } else if (g_ascii_strncasecmp("arm_aarch64", archname, 20) == 0) {
+            } else if (g_ascii_strncasecmp("arm_aarch64", archname, 20) == 0
+                       || g_ascii_strncasecmp("aarch64", archname, 20) == 0) {
                 archs[fARCH_aarch64] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture ARM aarch64\n", sourcename);

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -355,7 +355,8 @@ void extract_arch_from_text(gchar *archname, const gchar* sourcename, bool* arch
                 archs[fARCH_x86_64] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture x86_64\n", sourcename);
-            } else if (g_ascii_strncasecmp("arm", archname, 20) == 0) {
+            } else if (g_ascii_strncasecmp("arm", archname, 20) == 0
+                       || g_ascii_strncasecmp("armhf", archname, 20) == 0) {
                 archs[fARCH_arm] = 1;
                 if (verbose)
                     fprintf(stderr, "%s used for determining architecture ARM\n", sourcename);


### PR DESCRIPTION
Allows using armhf and aarch64 as architecture names on appimagetool. Doesn't remove the old names ("arm", "arm_aarch64") to avoid breaking scripts of possible users.

Closes #1114 