### PR TITLE
Fix building with GCC 10

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -52,7 +52,7 @@ if(NOT USE_SYSTEM_MKSQUASHFS)
 
     ExternalProject_Add(mksquashfs
         GIT_REPOSITORY https://github.com/plougher/squashfs-tools/
-        GIT_TAG 4.4
+        GIT_TAG 4.4-git.1
         UPDATE_COMMAND ""  # Make sure CMake won't try to fetch updates unnecessarily and hence rebuild the dependency every time
         CONFIGURE_COMMAND ${SED} -i "s|CFLAGS += -DXZ_SUPPORT|CFLAGS += ${mksquashfs_cflags}|g" <SOURCE_DIR>/squashfs-tools/Makefile
         COMMAND ${SED} -i "s|LIBS += -llzma|LIBS += -Bstatic ${mksquashfs_ldflags}|g" <SOURCE_DIR>/squashfs-tools/Makefile


### PR DESCRIPTION
Upgrades squashfs-tools to version 4.4-git.1, as this release [contains mainly bugfixes](https://github.com/plougher/squashfs-tools/commits/ddfb69d50971710502c9818a1fd1be42497e9808), and fixes building with GCC 10.
Depends on this libappimage PR: https://github.com/AppImage/libappimage/pull/153