### PR TITLE
feat:  Allow pling.com as update source

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -967,7 +967,8 @@ main (int argc, char *argv[])
             if(!g_str_has_prefix(updateinformation,"zsync|"))
                 if(!g_str_has_prefix(updateinformation,"bintray-zsync|"))
                     if(!g_str_has_prefix(updateinformation,"gh-releases-zsync|"))
-                        die("The provided updateinformation is not in a recognized format");
+                        if(!g_str_has_prefix(updateinformation,"pling-v1-zsync|"))
+                            die("The provided updateinformation is not in a recognized format");
                 
             gchar **ui_type = g_strsplit_set(updateinformation, "|", -1);
                         


### PR DESCRIPTION
Allow updates from pling.com and appimagehub.com. The purposed format for the whole update information would be:

`pling-v1-zsync|<content id>|<file name matching pattern>`

closes #1152