### PR TITLE
ci: Fix building with Podman

### DIFF
--- a/ci/build-binaries-and-appimage.sh
+++ b/ci/build-binaries-and-appimage.sh
@@ -15,8 +15,16 @@ export PATH=/deps/bin:"$PATH"
 echo "$KEY" | md5sum
 
 # we always build in a temporary directory
-# use RAM disk if possible
+# use RAM disk if possible and if enough space available
+USE_SHM=0
 if [ -d /dev/shm ] && mount | grep /dev/shm | grep -v -q noexec; then
+    SHM_FREE_KIB_MIN=$((1 * 1024 * 1024))
+    SHM_FREE_KIB=$(df -P -k /dev/shm | tail -n 1 | sed -e 's/ \+/ /g' | cut -d ' ' -f 4)
+    if [[ "$SHM_FREE_KIB" != "" ]] && [ $SHM_FREE_KIB -ge $SHM_FREE_KIB_MIN ]; then
+        USE_SHM=1
+    fi
+fi
+if [[ "$USE_SHM" = "1" ]]; then
     TEMP_BASE=/dev/shm
 elif [ -d /docker-ramdisk ]; then
     TEMP_BASE=/docker-ramdisk

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -79,6 +79,7 @@ fi
 # TODO: make gnupg home available, e.g., through "-v" "$HOME"/.gnupg:/root/.gnupg
 # TODO: this ^ won't work since we don't build as root any more
 # note: we enforce using the same UID in the container as outside, so that the created files are owned by the caller
+env PODMAN_USERNS=${PODMAN_USERNS:-keep-id} \
 docker run --rm \
     --user "$uid" \
     "${common_docker_opts[@]}" \


### PR DESCRIPTION
I had two issues building with Podman:

1.  `/dev/shm` did not have available space--on a host with ~16 GiB of RAM.  To work around this, I added a check that at least 1 GiB of space is available or else `/dev/shm` won't be used.

2.  Permission denied errors when moving binaries to `/out` when running rootlessly.  The user ID inside the container was not mapping to the host user ID.  Setting `PODMAN_USERNS=keep-id` solves this.  The use of this environment variable instead of the equivalent `--userns` option should ensure that Docker runs are not affected by this change.  (I do not override `$PODMAN_USERNS` if it is already set, so that users can easily override it if needed for their host system.)

Tested on Alpine Linux edge x86_64 with Podman 3.4.4.  (`apk add podman-docker` provides a shim for `docker` that invokes `podman`.)