### PR TITLE
Allow signing with passphrase

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -1155,9 +1155,16 @@ main (int argc, char *argv[])
                     strcat(key_arg, "'");
                 }
 
+                // passing the passphrase via the environment is at least better than using a CLI parameter
+                gchar *sign_passphrase = getenv("APPIMAGETOOL_SIGN_PASSPHRASE");
+
                 sprintf(command,
-                    "%s --batch --detach-sign --armor %s %s %s",
-                    gpg2_path, key_arg ? key_arg : "", sign_args ? sign_args : "", digestfile
+                    "%s --detach-sign --armor %s %s %s %s",
+                    gpg2_path,
+                    key_arg ? key_arg : "",
+                    sign_args ? sign_args : "",
+                    sign_passphrase != NULL ? "--passphrase-fd 0 --pinentry-mode loopback" : "",
+                    digestfile
                 );
 
                 free(key_arg);
@@ -1166,12 +1173,25 @@ main (int argc, char *argv[])
                 if (verbose)
                     fprintf(stderr, "%s\n", command);
 
-                fp = popen(command, "r");
+                fp = popen(command, "w");
+
+                if (fp == NULL) {
+                    perror("ERROR: popen() call failed");
+                    exit(1);
+                }
+
+                // write passphrase to stdin (fd 0 of subprocess)
+                if (sign_passphrase != NULL) {
+                    if (fwrite(sign_passphrase, sizeof(char), strlen(sign_passphrase), fp) != strlen(sign_passphrase)) {
+                        perror("ERROR: failed to pass passphrase to process, exiting");
+                        exit(1);
+                    }
+                }
 
                 if (pclose(fp) != 0) {
-                    fprintf(stderr, "ERROR: %s command did not succeed, could not sign, continuing\n", using_gpg ? "gpg" : "gpg2");
+                    int errno_backup = errno;
+                    fprintf(stderr, "ERROR: %s command did not succeed, could not sign (%s), continuing\n", using_gpg ? "gpg" : "gpg2", strerror(errno_backup));
                 } else {
-
                     fp = NULL;
 
                     FILE* destinationfp = fopen(destination, "r+");


### PR DESCRIPTION
Using a password-protected key in a CI environment is hardly possible at the moment, since there is no reliable way to really pass the passphrase to the gpg process. This PR introduces the `APPIMAGETOOL_SIGN_PASSPHRASE` environment variable, which can be used to pass the passphrase properly to the signing process.

TODO: documentation (please feel free to add comments where the variable should be added)