### PR TITLE
Some i18n changes for the appimage.org website

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -40,7 +40,7 @@ http {
             index  index.html;
 
             set $first_language $http_accept_language;
-            if ($http_accept_language ~* '^(.+?),') {
+            if ($http_accept_language ~* '^([a-z0-9\-]+),?') {
                 set $first_language $1;
             }
 
@@ -50,6 +50,9 @@ http {
             }
             if ($first_language ~* 'zh') {
                 set $language_suffix 'zh';
+            }
+            if ($first_language ~* 'zh-(?:hant|tw|hk|mo)') {
+                set $language_suffix 'zh_Hant';
             }
             if ($first_language ~* 'fr') {
                 set $language_suffix 'fr';

--- a/index.jinja2
+++ b/index.jinja2
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ lang_tag }}">
 <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>

--- a/translator.py
+++ b/translator.py
@@ -31,6 +31,7 @@ def render_pages():
         )
 
         locale = locale.split(".mo")[0]
+        lang_tag = locale.replace("_", "-")
 
         template = jinja_env.get_template("index.jinja2")
 
@@ -43,7 +44,7 @@ def render_pages():
         print("Rendering page %s for locale %s" % (filename, locale))
 
         with open(os.path.join(out_dir, filename), "w") as f:
-            html = template.render(languages=[locale])
+            html = template.render(languages=[locale], lang_tag=lang_tag)
             f.write(html)
 
     index_html_path = os.path.join(out_dir, "index.html")

--- a/translator.py
+++ b/translator.py
@@ -36,6 +36,9 @@ def render_pages():
         template = jinja_env.get_template("index.jinja2")
 
         translation = babel.support.Translations.load(localedir, [locale])
+        if locale != "en":
+            fallback_translation = babel.support.Translations.load(localedir, ["en"])
+            translation.add_fallback(fallback_translation)
 
         jinja_env.install_gettext_translations(translation)
 


### PR DESCRIPTION
- Enable Chinese (Traditional) translations: This matches the `Accept-Language` language tags `zh-Hant`/`zh-Hant-TW`/`zh-Hant-HK`/`zh-Hant-MO`/`zh-Hant-*`/`zh-TW`/`zh-HK`/`zh-MO`. I also changed the regex a bit to fix the incorrect assumption that there must be a comma (there won't be a comma when there is only one Accept-Language value).
- Set correct language tag in translated page: The `lang` attribute on the `<html>` element now reflects the actual language of the page. This is needed for browsers to choose the correct font variant to use for CJK text.
- Add English as fallback translations: Without this, untranslated messages falls back to the message id, which is undesirable (see screenshot for example).  
![example](https://user-images.githubusercontent.com/2397650/156502629-5d48b04e-1498-4672-a1a1-5e529608d912.png)
