### PR TITLE
Add --mksquashfs-opt

### DIFF
--- a/ci/test-appimagetool.sh
+++ b/ci/test-appimagetool.sh
@@ -117,3 +117,21 @@ if [ "$hash1" != "$hash2" ]; then
     echo "Hash $hash1 doesn't match hash $hash2!"
     exit 1
 fi
+
+log "check --mksquashfs-opt forwarding"
+out=$("$appimagetool" appimagetool.AppDir appimagetool.AppImage --mksquashfs-opt "-misspelt-option" 2>&1)
+echo "${out}" | grep -q "invalid option"
+"$appimagetool" appimagetool.AppDir appimagetool.AppImage.1
+"$appimagetool" appimagetool.AppDir appimagetool.AppImage.2 --mksquashfs-opt "-mem" --mksquashfs-opt "100M"
+"$appimagetool" appimagetool.AppDir appimagetool.AppImage.3 --mksquashfs-opt "-all-time" --mksquashfs-opt "12345"
+hash1=$(sha256sum appimagetool.AppImage.1 | awk '{print $1}')
+hash2=$(sha256sum appimagetool.AppImage.2 | awk '{print $1}')
+hash3=$(sha256sum appimagetool.AppImage.3 | awk '{print $1}')
+if [ "$hash1" != "$hash2" ]; then
+    echo "Hashes of regular and mem-restricted AppImages differ"
+    exit 1
+fi
+if [ "$hash1" == "$hash3" ]; then
+    echo "Hashes of regular and mtime-modified AppImages don't differ"
+    exit 1
+fi

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -82,6 +82,7 @@ static gboolean guess_update_information = FALSE;
 gchar *bintray_user = NULL;
 gchar *bintray_repo = NULL;
 gchar *sqfs_comp = "gzip";
+gchar **sqfs_opts = NULL;
 gchar *exclude_file = NULL;
 gchar *runtime_file = NULL;
 gchar *sign_args = NULL;
@@ -142,7 +143,9 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         gchar* offset_string;
         offset_string = g_strdup_printf("%i", offset);
 
-        char* args[32];
+        guint sqfs_opts_len = sqfs_opts ? g_strv_length(sqfs_opts) : 0;
+
+        char* args[32 + sqfs_opts_len];
         bool use_xz = strcmp(sqfs_comp, "xz") >= 0;
 
         int i = 0;
@@ -155,8 +158,8 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         args[i++] = destination;
         args[i++] = "-offset";
         args[i++] = offset_string;
-        args[i++] = "-comp";
 
+        args[i++] = "-comp";
         if (use_xz)
             args[i++] = "xz";
         else
@@ -199,6 +202,10 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
 
         args[i++] = "-mkfs-time";
         args[i++] = "0";
+
+        for (guint sqfs_opts_idx = 0; sqfs_opts_idx < sqfs_opts_len; sqfs_opts_idx++) {
+            args[i++] = sqfs_opts[sqfs_opts_idx];
+        }
 
         args[i++] = 0;
 
@@ -505,6 +512,7 @@ static GOptionEntry entries[] =
     { "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose, "Produce verbose output", NULL },
     { "sign", 's', 0, G_OPTION_ARG_NONE, &sign, "Sign with gpg[2]", NULL },
     { "comp", 0, 0, G_OPTION_ARG_STRING, &sqfs_comp, "Squashfs compression", NULL },
+    { "mksquashfs-opt", 0, 0, G_OPTION_ARG_STRING_ARRAY, &sqfs_opts, "Argument to pass through to mksquashfs; can be specified multiple times", NULL },
     { "no-appstream", 'n', 0, G_OPTION_ARG_NONE, &no_appstream, "Do not check AppStream metadata", NULL },
     { "exclude-file", 0, 0, G_OPTION_ARG_STRING, &exclude_file, _exclude_file_desc, NULL },
     { "runtime-file", 0, 0, G_OPTION_ARG_STRING, &runtime_file, "Runtime file to use", NULL },

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -145,7 +145,8 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
 
         guint sqfs_opts_len = sqfs_opts ? g_strv_length(sqfs_opts) : 0;
 
-        char* args[32 + sqfs_opts_len];
+        int max_num_args = sqfs_opts_len + 22;
+        char* args[max_num_args];
         bool use_xz = strcmp(sqfs_comp, "xz") >= 0;
 
         int i = 0;
@@ -203,7 +204,7 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         args[i++] = "-mkfs-time";
         args[i++] = "0";
 
-        for (guint sqfs_opts_idx = 0; sqfs_opts_idx < sqfs_opts_len; sqfs_opts_idx++) {
+        for (guint sqfs_opts_idx = 0; sqfs_opts_idx < sqfs_opts_len; ++sqfs_opts_idx) {
             args[i++] = sqfs_opts[sqfs_opts_idx];
         }
 


### PR DESCRIPTION
This PR adds a new `--mksquashfs-opt` argument to appimagekit. It can be used to pass through arbitrary options to `mksquashfs`. For example to limit mksquashfs memory consumption to 100MB you can invoke apppimagekit like
```
./appimagetool AppDir program.AppImage --mksquashfs-opt "-mem" --mksquashfs-opt "100M"
```

Note that specifying invalid arguments to mksquashfs will print error messages, but appimagetool will still claim success and exit with return code 0. I believe this is the existing behaviour. This should probably be fixed as well, but in a separate issue/PR.

Closes https://github.com/AppImage/AppImageKit/issues/1186