### PR TITLE
Replace popen and fork/exec with GIO subprocessing

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -12,6 +12,7 @@ import_pkgconfig_target(TARGET_NAME libfuse PKGCONFIG_TARGET fuse)
 # openssl is required for optional tools only, and doesn't need to be enforced
 # FIXME: remove dependency to openssl by implementing own SHA hashes in libappimage_hashlib
 import_pkgconfig_target(TARGET_NAME libssl PKGCONFIG_TARGET openssl OPTIONAL)
+import_pkgconfig_target(TARGET_NAME libgio PKGCONFIG_TARGET gio OPTIONAL)
 
 
 if(USE_CCACHE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(appimagetool
     xdg-basedir
     libappimage_shared
     libglib
+    libgio
     libzlib
     xz
 )


### PR DESCRIPTION
This PR reworks the subprocess handling within appimagetool. It is supposed to fix some issues within automated processes such as building AppImages in CI systems. For instance, I recently observed the tool to be hanging within non-interactive Docker containers. After spending some time recreating such an environment locally, the tool seemed to run fine, but a `gpg[2]` signing process was not closed correctly.

Since this is a relatively big refactoring that touches half of the AppImage creation, this requires extensive testing. I already started testing most combinations of the flags and scenarios.