### PR TITLE
Preserve timestamps when extracting the squashfs

### DIFF
--- a/ci/test-appimagetool.sh
+++ b/ci/test-appimagetool.sh
@@ -135,3 +135,12 @@ if [ "$hash1" == "$hash3" ]; then
     echo "Hashes of regular and mtime-modified AppImages don't differ"
     exit 1
 fi
+
+log "check mtimes are not lost when extracting"
+./appimagetool.AppImage.3 --appimage-extract
+if [ "$(stat -c %Y squashfs-root/appimagetool.png)" != "12345" ]; then
+    echo "mtime of appimagetool.png is not 12345 (as set by mksquashfs \"-all-time\"):"
+    ls -la squashfs-root
+    exit 1
+fi
+rm -rf squashfs-root

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -403,6 +403,11 @@ bool extract_appimage(const char* const appimage_path, const char* const _prefix
                             fwrite(buf, 1, bytes_at_a_time, f);
                             bytes_already_read = bytes_already_read + bytes_at_a_time;
                         }
+                        fflush(f);
+                        int fd = fileno(f);
+                        struct timespec times[] = { st.st_atim, st.st_mtim };
+                        if (futimens(fd, times) != 0)
+                            fprintf(stderr, "futimens: %s\n", strerror(errno));
                         fclose(f);
                         chmod(prefixed_path_to_extract, st.st_mode);
                         if (!rv)


### PR DESCRIPTION
Closes https://github.com/AppImage/AppImageKit/issues/1151