### PR TITLE
Make appimagetool use zstd

### DIFF
--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -179,8 +179,8 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
 
         args[i++] = "-comp";
         
-        if (use_xz)
-            args[i++] = "xz";
+        if (use_zstd)
+            args[i++] = "zstd";
         else
             args[i++] = sqfs_comp;
 

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -85,7 +85,7 @@ gchar *updateinformation = NULL;
 static gboolean guess_update_information = FALSE;
 gchar *bintray_user = NULL;
 gchar *bintray_repo = NULL;
-gchar *sqfs_comp = "zstd";
+gchar *sqfs_comp = "";
 gchar **sqfs_opts = NULL;
 gchar *exclude_file = NULL;
 gchar *runtime_file = NULL;
@@ -617,7 +617,7 @@ main (int argc, char *argv[])
     if (showVersionOnly)
         exit(0);
 
-    if(!((0 == strcmp(sqfs_comp, "zstd")) || strcmp(sqfs_comp, "gzip")) || (0 ==strcmp(sqfs_comp, "xz"))))
+    if (!((0 == strcmp(sqfs_comp, "zstd")) || strcmp(sqfs_comp, "gzip") || (0 == strcmp(sqfs_comp, "xz"))))
         die("Only zstd (recommended), gzip (faster execution, larger files) and xz (slower execution, smaller files) compression is supported at the moment. Let us know if there are reasons for more, should be easy to add. You could help the project by doing some systematic size/performance measurements. Watch for size, execution speed, and zsync delta size.");
     /* Check for dependencies here. Better fail early if they are not present. */
     if(! g_find_program_in_path ("file"))

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -617,8 +617,8 @@ main (int argc, char *argv[])
     if (showVersionOnly)
         exit(0);
 
-    if(!((0 == strcmp(sqfs_comp, "gzip")) || (0 ==strcmp(sqfs_comp, "xz"))))
-        die("Only gzip (faster execution, larger files) and xz (slower execution, smaller files) compression is supported at the moment. Let us know if there are reasons for more, should be easy to add. You could help the project by doing some systematic size/performance measurements. Watch for size, execution speed, and zsync delta size.");
+    if(!((0 == strcmp(sqfs_comp, "zstd")) || strcmp(sqfs_comp, "gzip")) || (0 ==strcmp(sqfs_comp, "xz"))))
+        die("Only zstd (recommended), gzip (faster execution, larger files) and xz (slower execution, smaller files) compression is supported at the moment. Let us know if there are reasons for more, should be easy to add. You could help the project by doing some systematic size/performance measurements. Watch for size, execution speed, and zsync delta size.");
     /* Check for dependencies here. Better fail early if they are not present. */
     if(! g_find_program_in_path ("file"))
         die("file command is missing but required, please install it");

--- a/src/appimagetool.c
+++ b/src/appimagetool.c
@@ -85,7 +85,7 @@ gchar *updateinformation = NULL;
 static gboolean guess_update_information = FALSE;
 gchar *bintray_user = NULL;
 gchar *bintray_repo = NULL;
-gchar *sqfs_comp = "gzip";
+gchar *sqfs_comp = "zstd";
 gchar **sqfs_opts = NULL;
 gchar *exclude_file = NULL;
 gchar *runtime_file = NULL;
@@ -163,6 +163,7 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
 
         int max_num_args = sqfs_opts_len + 22;
         char* args[max_num_args];
+        bool use_zstd = strcmp(sqfs_comp, "zstd") >= 0;
         bool use_xz = strcmp(sqfs_comp, "xz") >= 0;
 
         int i = 0;
@@ -177,6 +178,7 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
         args[i++] = offset_string;
 
         args[i++] = "-comp";
+        
         if (use_xz)
             args[i++] = "xz";
         else
@@ -184,6 +186,12 @@ int sfs_mksquashfs(char *source, char *destination, int offset) {
 
         args[i++] = "-root-owned";
         args[i++] = "-noappend";
+
+        if (use_zstd) {
+            // https://github.com/probonopd/go-appimage/blob/785b52511085b37e09e967c0bc2ebd7f9401e6b9/src/appimagetool/appimagetool.go#L440
+            args[i++] = "-b";
+            args[i++] = "1M";
+        }
 
         if (use_xz) {
             // https://jonathancarter.org/2015/04/06/squashfs-performance-testing/ says:


### PR DESCRIPTION
In anticipation of using https://github.com/AppImage/type2-runtime and

* https://github.com/AppImage/AppImageSpec/issues/34

use `zstd` as the default compression in `appiamgetool`.